### PR TITLE
Add workspace hooks runner

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,5 +6,6 @@ export * from "./config/workflow-loader.js";
 export * from "./domain/model.js";
 export * from "./errors/codes.js";
 export * from "./logging/fields.js";
+export * from "./workspace/hooks.js";
 export * from "./workspace/path-safety.js";
 export * from "./workspace/workspace-manager.js";

--- a/src/workspace/hooks.ts
+++ b/src/workspace/hooks.ts
@@ -1,0 +1,265 @@
+import { spawn } from "node:child_process";
+
+import { ERROR_CODES } from "../errors/codes.js";
+
+const DEFAULT_OUTPUT_LIMIT = 4_000;
+
+export const WORKSPACE_HOOK_NAMES = [
+  "afterCreate",
+  "beforeRun",
+  "afterRun",
+  "beforeRemove",
+] as const;
+
+export type WorkspaceHookName = (typeof WORKSPACE_HOOK_NAMES)[number];
+
+export interface HookCommandResult {
+  exitCode: number | null;
+  signal: NodeJS.Signals | null;
+  stdout: string;
+  stderr: string;
+}
+
+export interface WorkspaceHookLogEntry {
+  level: "info" | "warn" | "error";
+  event:
+    | "workspace_hook_started"
+    | "workspace_hook_completed"
+    | "workspace_hook_failed"
+    | "workspace_hook_timed_out";
+  hook: WorkspaceHookName;
+  workspacePath: string;
+  durationMs?: number;
+  exitCode?: number | null;
+  errorCode?: string;
+  stdout?: string;
+  stderr?: string;
+}
+
+export type WorkspaceHookLogger = (entry: WorkspaceHookLogEntry) => void;
+
+export interface WorkspaceHookRunnerConfig {
+  afterCreate: string | null;
+  beforeRun: string | null;
+  afterRun: string | null;
+  beforeRemove: string | null;
+  timeoutMs: number;
+}
+
+export type HookCommandExecutor = (
+  script: string,
+  options: { cwd: string; timeoutMs: number },
+) => Promise<HookCommandResult>;
+
+export interface RunWorkspaceHookOptions {
+  name: WorkspaceHookName;
+  workspacePath: string;
+}
+
+export class WorkspaceHookError extends Error {
+  readonly code: string;
+  readonly hook: WorkspaceHookName;
+  readonly workspacePath: string;
+  readonly exitCode: number | null;
+  readonly stdout: string;
+  readonly stderr: string;
+
+  constructor(input: {
+    code: string;
+    message: string;
+    hook: WorkspaceHookName;
+    workspacePath: string;
+    exitCode?: number | null;
+    stdout?: string;
+    stderr?: string;
+    cause?: unknown;
+  }) {
+    super(input.message, { cause: input.cause });
+    this.name = "WorkspaceHookError";
+    this.code = input.code;
+    this.hook = input.hook;
+    this.workspacePath = input.workspacePath;
+    this.exitCode = input.exitCode ?? null;
+    this.stdout = input.stdout ?? "";
+    this.stderr = input.stderr ?? "";
+  }
+}
+
+export class WorkspaceHookRunner {
+  readonly #config: WorkspaceHookRunnerConfig;
+  readonly #execute: HookCommandExecutor;
+  readonly #log: WorkspaceHookLogger;
+  readonly #outputLimit: number;
+
+  constructor(input: {
+    config: WorkspaceHookRunnerConfig;
+    execute?: HookCommandExecutor;
+    log?: WorkspaceHookLogger;
+    outputLimit?: number;
+  }) {
+    this.#config = input.config;
+    this.#execute = input.execute ?? executeShellHook;
+    this.#log = input.log ?? (() => {});
+    this.#outputLimit = input.outputLimit ?? DEFAULT_OUTPUT_LIMIT;
+  }
+
+  async run(options: RunWorkspaceHookOptions): Promise<boolean> {
+    const script = this.#config[options.name];
+    if (!script) {
+      return false;
+    }
+
+    const startedAt = Date.now();
+    this.#log({
+      level: "info",
+      event: "workspace_hook_started",
+      hook: options.name,
+      workspacePath: options.workspacePath,
+    });
+
+    try {
+      const result = await this.#execute(script, {
+        cwd: options.workspacePath,
+        timeoutMs: this.#config.timeoutMs,
+      });
+      const durationMs = Date.now() - startedAt;
+
+      if (result.exitCode !== 0) {
+        const error = new WorkspaceHookError({
+          code: ERROR_CODES.hookFailed,
+          message: `Workspace hook '${options.name}' failed with exit code ${result.exitCode ?? "unknown"}.`,
+          hook: options.name,
+          workspacePath: options.workspacePath,
+          exitCode: result.exitCode,
+          stdout: truncateOutput(result.stdout, this.#outputLimit),
+          stderr: truncateOutput(result.stderr, this.#outputLimit),
+        });
+        this.#log({
+          level: "error",
+          event: "workspace_hook_failed",
+          hook: options.name,
+          workspacePath: options.workspacePath,
+          durationMs,
+          exitCode: error.exitCode,
+          errorCode: error.code,
+          stdout: error.stdout,
+          stderr: error.stderr,
+        });
+        throw error;
+      }
+
+      this.#log({
+        level: "info",
+        event: "workspace_hook_completed",
+        hook: options.name,
+        workspacePath: options.workspacePath,
+        durationMs,
+        exitCode: result.exitCode,
+        stdout: truncateOutput(result.stdout, this.#outputLimit),
+        stderr: truncateOutput(result.stderr, this.#outputLimit),
+      });
+      return true;
+    } catch (error) {
+      if (error instanceof WorkspaceHookError) {
+        throw error;
+      }
+
+      const durationMs = Date.now() - startedAt;
+      const hookError = new WorkspaceHookError({
+        code: ERROR_CODES.hookTimedOut,
+        message: `Workspace hook '${options.name}' timed out after ${this.#config.timeoutMs} ms.`,
+        hook: options.name,
+        workspacePath: options.workspacePath,
+        cause: error,
+      });
+      this.#log({
+        level: "error",
+        event: "workspace_hook_timed_out",
+        hook: options.name,
+        workspacePath: options.workspacePath,
+        durationMs,
+        errorCode: hookError.code,
+      });
+      throw hookError;
+    }
+  }
+
+  async runBestEffort(options: RunWorkspaceHookOptions): Promise<boolean> {
+    try {
+      return await this.run(options);
+    } catch {
+      return false;
+    }
+  }
+}
+
+export async function executeShellHook(
+  script: string,
+  options: { cwd: string; timeoutMs: number },
+): Promise<HookCommandResult> {
+  return await new Promise<HookCommandResult>((resolve, reject) => {
+    const child = spawn("sh", ["-lc", script], {
+      cwd: options.cwd,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+    let settled = false;
+
+    const timeoutHandle = setTimeout(() => {
+      if (settled) {
+        return;
+      }
+
+      settled = true;
+      child.kill("SIGTERM");
+      reject(
+        new Error(`Workspace hook timed out after ${options.timeoutMs} ms.`),
+      );
+    }, options.timeoutMs);
+
+    child.stdout?.setEncoding("utf8");
+    child.stdout?.on("data", (chunk: string) => {
+      stdout += chunk;
+    });
+
+    child.stderr?.setEncoding("utf8");
+    child.stderr?.on("data", (chunk: string) => {
+      stderr += chunk;
+    });
+
+    child.on("error", (error) => {
+      if (settled) {
+        return;
+      }
+
+      settled = true;
+      clearTimeout(timeoutHandle);
+      reject(error);
+    });
+
+    child.on("close", (exitCode, signal) => {
+      if (settled) {
+        return;
+      }
+
+      settled = true;
+      clearTimeout(timeoutHandle);
+      resolve({
+        exitCode,
+        signal,
+        stdout,
+        stderr,
+      });
+    });
+  });
+}
+
+function truncateOutput(value: string, limit: number): string {
+  if (value.length <= limit) {
+    return value;
+  }
+
+  return `${value.slice(0, limit)}...[truncated]`;
+}

--- a/src/workspace/workspace-manager.ts
+++ b/src/workspace/workspace-manager.ts
@@ -2,6 +2,7 @@ import { promises as fs } from "node:fs";
 
 import type { Workspace } from "../domain/model.js";
 import { ERROR_CODES } from "../errors/codes.js";
+import type { WorkspaceHookRunner } from "./hooks.js";
 import {
   WorkspacePathError,
   type WorkspacePathInfo,
@@ -20,15 +21,18 @@ interface FileSystemLike {
 export interface WorkspaceManagerOptions {
   root: string;
   fs?: FileSystemLike;
+  hooks?: WorkspaceHookRunner | null;
 }
 
 export class WorkspaceManager {
   readonly root: string;
   readonly #fs: FileSystemLike;
+  readonly #hooks: WorkspaceHookRunner | null;
 
   constructor(options: WorkspaceManagerOptions) {
     this.root = options.root;
     this.#fs = options.fs ?? fs;
+    this.#hooks = isHookRunner(options.hooks) ? options.hooks : null;
   }
 
   resolveForIssue(issueIdentifier: string): WorkspacePathInfo {
@@ -42,12 +46,20 @@ export class WorkspaceManager {
     try {
       await this.#fs.mkdir(workspaceRoot, { recursive: true });
       const createdNow = await this.#ensureWorkspaceDirectory(workspacePath);
-
-      return {
+      const workspace = {
         path: workspacePath,
         workspaceKey,
         createdNow,
       };
+
+      if (createdNow) {
+        await this.#hooks?.run({
+          name: "afterCreate",
+          workspacePath,
+        });
+      }
+
+      return workspace;
     } catch (error) {
       if (error instanceof WorkspacePathError) {
         throw error;
@@ -65,6 +77,14 @@ export class WorkspaceManager {
     const { workspacePath } = this.resolveForIssue(issueIdentifier);
 
     try {
+      const existsAsDirectory = await this.#workspaceExists(workspacePath);
+      if (existsAsDirectory) {
+        await this.#hooks?.runBestEffort({
+          name: "beforeRemove",
+          workspacePath,
+        });
+      }
+
       await this.#fs.rm(workspacePath, { force: true, recursive: true });
       return true;
     } catch (error) {
@@ -114,6 +134,32 @@ export class WorkspaceManager {
       throw error;
     }
   }
+
+  async #workspaceExists(workspacePath: string): Promise<boolean> {
+    try {
+      const current = await this.#fs.lstat(workspacePath);
+      return current.isDirectory();
+    } catch (error) {
+      if (isMissingPathError(error)) {
+        return false;
+      }
+
+      throw error;
+    }
+  }
+}
+
+function isHookRunner(
+  value: WorkspaceManagerOptions["hooks"],
+): value is WorkspaceHookRunner {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "run" in value &&
+    typeof value.run === "function" &&
+    "runBestEffort" in value &&
+    typeof value.runBestEffort === "function"
+  );
 }
 
 function isMissingPathError(

--- a/tests/workspace/hooks.test.ts
+++ b/tests/workspace/hooks.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  ERROR_CODES,
+  type WorkspaceHookError,
+  type WorkspaceHookLogEntry,
+  WorkspaceHookRunner,
+} from "../../src/index.js";
+
+describe("WorkspaceHookRunner", () => {
+  it("returns false when the requested hook is not configured", async () => {
+    const execute = vi.fn();
+    const runner = new WorkspaceHookRunner({
+      config: {
+        afterCreate: null,
+        beforeRun: null,
+        afterRun: null,
+        beforeRemove: null,
+        timeoutMs: 100,
+      },
+      execute,
+    });
+
+    await expect(
+      runner.run({
+        name: "beforeRun",
+        workspacePath: "/tmp/workspace",
+      }),
+    ).resolves.toBe(false);
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it("fails fatal hooks on non-zero exit codes and truncates logged output", async () => {
+    const logs: WorkspaceHookLogEntry[] = [];
+    const runner = new WorkspaceHookRunner({
+      config: {
+        afterCreate: "echo prepare",
+        beforeRun: "echo run",
+        afterRun: null,
+        beforeRemove: null,
+        timeoutMs: 500,
+      },
+      outputLimit: 12,
+      log: (entry) => {
+        logs.push(entry);
+      },
+      execute: vi.fn().mockResolvedValue({
+        exitCode: 12,
+        signal: null,
+        stdout: "1234567890abcdef",
+        stderr: "failure-details",
+      }),
+    });
+
+    await expect(
+      runner.run({
+        name: "beforeRun",
+        workspacePath: "/tmp/workspace",
+      }),
+    ).rejects.toThrowError(
+      expect.objectContaining<Partial<WorkspaceHookError>>({
+        code: ERROR_CODES.hookFailed,
+        exitCode: 12,
+        stdout: "1234567890ab...[truncated]",
+        stderr: "failure-deta...[truncated]",
+      }),
+    );
+
+    expect(logs).toEqual([
+      {
+        level: "info",
+        event: "workspace_hook_started",
+        hook: "beforeRun",
+        workspacePath: "/tmp/workspace",
+      },
+      expect.objectContaining({
+        level: "error",
+        event: "workspace_hook_failed",
+        hook: "beforeRun",
+        workspacePath: "/tmp/workspace",
+        exitCode: 12,
+        errorCode: ERROR_CODES.hookFailed,
+        stdout: "1234567890ab...[truncated]",
+        stderr: "failure-deta...[truncated]",
+      }),
+    ]);
+  });
+
+  it("maps executor failures to hook timeout errors", async () => {
+    const logs: WorkspaceHookLogEntry[] = [];
+    const runner = new WorkspaceHookRunner({
+      config: {
+        afterCreate: null,
+        beforeRun: "sleep 10",
+        afterRun: null,
+        beforeRemove: null,
+        timeoutMs: 25,
+      },
+      log: (entry) => {
+        logs.push(entry);
+      },
+      execute: vi.fn().mockRejectedValue(new Error("timed out")),
+    });
+
+    await expect(
+      runner.run({
+        name: "beforeRun",
+        workspacePath: "/tmp/workspace",
+      }),
+    ).rejects.toThrowError(
+      expect.objectContaining<Partial<WorkspaceHookError>>({
+        code: ERROR_CODES.hookTimedOut,
+      }),
+    );
+
+    expect(logs).toEqual([
+      {
+        level: "info",
+        event: "workspace_hook_started",
+        hook: "beforeRun",
+        workspacePath: "/tmp/workspace",
+      },
+      expect.objectContaining({
+        level: "error",
+        event: "workspace_hook_timed_out",
+        hook: "beforeRun",
+        workspacePath: "/tmp/workspace",
+        errorCode: ERROR_CODES.hookTimedOut,
+      }),
+    ]);
+  });
+
+  it("suppresses errors in best-effort mode", async () => {
+    const runner = new WorkspaceHookRunner({
+      config: {
+        afterCreate: null,
+        beforeRun: null,
+        afterRun: "echo cleanup",
+        beforeRemove: null,
+        timeoutMs: 100,
+      },
+      execute: vi.fn().mockResolvedValue({
+        exitCode: 1,
+        signal: null,
+        stdout: "",
+        stderr: "broken",
+      }),
+    });
+
+    await expect(
+      runner.runBestEffort({
+        name: "afterRun",
+        workspacePath: "/tmp/workspace",
+      }),
+    ).resolves.toBe(false);
+  });
+});

--- a/tests/workspace/workspace-manager.test.ts
+++ b/tests/workspace/workspace-manager.test.ts
@@ -5,7 +5,11 @@ import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { ERROR_CODES } from "../../src/errors/codes.js";
-import { WorkspaceManager, type WorkspacePathError } from "../../src/index.js";
+import {
+  WorkspaceHookRunner,
+  WorkspaceManager,
+  type WorkspacePathError,
+} from "../../src/index.js";
 
 const roots: string[] = [];
 
@@ -40,6 +44,65 @@ describe("WorkspaceManager", () => {
 
     expect(workspace.path).toBe(join(root, "ABC-123"));
     expect(workspace.createdNow).toBe(false);
+  });
+
+  it("runs afterCreate only for newly created workspaces", async () => {
+    const root = await createRoot();
+    const hookCalls: string[] = [];
+    const hooks = new WorkspaceHookRunner({
+      config: {
+        afterCreate: "prepare",
+        beforeRun: null,
+        afterRun: null,
+        beforeRemove: null,
+        timeoutMs: 100,
+      },
+      execute: async (_script, options) => {
+        hookCalls.push(options.cwd);
+        return {
+          exitCode: 0,
+          signal: null,
+          stdout: "",
+          stderr: "",
+        };
+      },
+    });
+    const manager = new WorkspaceManager({ root, hooks });
+
+    const first = await manager.createForIssue("ABC-123");
+    await manager.createForIssue("ABC-123");
+
+    expect(hookCalls).toEqual([first.path]);
+  });
+
+  it("runs beforeRemove as a best-effort hook when deleting an existing workspace", async () => {
+    const root = await createRoot();
+    const hookCalls: string[] = [];
+    const hooks = new WorkspaceHookRunner({
+      config: {
+        afterCreate: null,
+        beforeRun: null,
+        afterRun: null,
+        beforeRemove: "cleanup",
+        timeoutMs: 100,
+      },
+      execute: async (_script, options) => {
+        hookCalls.push(options.cwd);
+        return {
+          exitCode: 1,
+          signal: null,
+          stdout: "",
+          stderr: "ignored",
+        };
+      },
+    });
+    const manager = new WorkspaceManager({ root, hooks });
+
+    const workspace = await manager.createForIssue("ABC-123");
+    const removed = await manager.removeForIssue("ABC-123");
+
+    expect(removed).toBe(true);
+    expect(hookCalls).toEqual([workspace.path]);
   });
 
   it("fails safely when the workspace path already exists as a file", async () => {


### PR DESCRIPTION
## Summary
- add a workspace hook runner for after_create, before_run, after_run, and before_remove
- wire workspace manager into after_create and before_remove lifecycle handling
- add spec-aligned tests for fatal hook failures, best-effort cleanup hooks, timeouts, and output truncation

## Scope
Implements Task 7 from .
Aligns behavior with  Section 9.4 workspace hook semantics.

## Testing
- pnpm test
- pnpm typecheck
- pnpm lint
