### PR TITLE
Implement workflow watch and reload

### DIFF
--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -69,3 +69,30 @@ export type DispatchValidationResult =
       ok: false;
       error: DispatchValidationFailure;
     };
+
+export interface WorkflowSnapshot {
+  definition: {
+    workflowPath: string;
+    config: Record<string, unknown>;
+    promptTemplate: string;
+  };
+  config: ResolvedWorkflowConfig;
+  dispatchValidation: DispatchValidationResult;
+  loadedAt: string;
+}
+
+export type WorkflowReloadReason = "manual" | "filesystem_event";
+
+export type WorkflowReloadResult =
+  | {
+      ok: true;
+      reason: WorkflowReloadReason;
+      previousSnapshot: WorkflowSnapshot;
+      snapshot: WorkflowSnapshot;
+    }
+  | {
+      ok: false;
+      reason: WorkflowReloadReason;
+      currentSnapshot: WorkflowSnapshot;
+      error: unknown;
+    };

--- a/src/config/workflow-watch.ts
+++ b/src/config/workflow-watch.ts
@@ -1,0 +1,221 @@
+import { type FSWatcher, watch } from "node:fs";
+
+import {
+  resolveWorkflowConfig,
+  validateDispatchConfig,
+} from "./config-resolver.js";
+import type {
+  WorkflowReloadReason,
+  WorkflowReloadResult,
+  WorkflowSnapshot,
+} from "./types.js";
+import {
+  loadWorkflowDefinition,
+  resolveWorkflowPath,
+} from "./workflow-loader.js";
+
+const DEFAULT_WATCH_DEBOUNCE_MS = 100;
+
+export interface WorkflowWatcherHooks {
+  onReload?: (result: {
+    reason: WorkflowReloadReason;
+    previousSnapshot: WorkflowSnapshot;
+    snapshot: WorkflowSnapshot;
+  }) => void | Promise<void>;
+  onError?: (result: {
+    reason: WorkflowReloadReason;
+    currentSnapshot: WorkflowSnapshot;
+    error: unknown;
+  }) => void | Promise<void>;
+}
+
+export interface WorkflowWatcherOptions extends WorkflowWatcherHooks {
+  workflowPath?: string;
+  environment?: NodeJS.ProcessEnv;
+  debounceMs?: number;
+}
+
+export async function loadWorkflowSnapshot(
+  workflowPath?: string,
+  environment: NodeJS.ProcessEnv = process.env,
+): Promise<WorkflowSnapshot> {
+  const definition = await loadWorkflowDefinition(workflowPath);
+  const config = resolveWorkflowConfig(definition, environment);
+
+  return {
+    definition,
+    config,
+    dispatchValidation: validateDispatchConfig(config),
+    loadedAt: new Date().toISOString(),
+  };
+}
+
+export class WorkflowWatcher {
+  readonly workflowPath: string;
+
+  #currentSnapshot: WorkflowSnapshot;
+  #environment: NodeJS.ProcessEnv;
+  #watcher: FSWatcher | null = null;
+  #debounceMs: number;
+  #debounceTimer: ReturnType<typeof setTimeout> | null = null;
+  #reloadInFlight: Promise<WorkflowReloadResult> | null = null;
+  #reloadQueued = false;
+  #hooks: WorkflowWatcherHooks;
+
+  private constructor(input: {
+    currentSnapshot: WorkflowSnapshot;
+    workflowPath: string;
+    environment: NodeJS.ProcessEnv;
+    debounceMs: number;
+    hooks: WorkflowWatcherHooks;
+  }) {
+    this.#currentSnapshot = input.currentSnapshot;
+    this.workflowPath = input.workflowPath;
+    this.#environment = input.environment;
+    this.#debounceMs = input.debounceMs;
+    this.#hooks = input.hooks;
+  }
+
+  static async create(
+    options: WorkflowWatcherOptions = {},
+  ): Promise<WorkflowWatcher> {
+    const environment = options.environment ?? process.env;
+    const workflowPath = resolveWorkflowPath(options.workflowPath);
+    const currentSnapshot = await loadWorkflowSnapshot(
+      workflowPath,
+      environment,
+    );
+
+    return new WorkflowWatcher({
+      currentSnapshot,
+      workflowPath,
+      environment,
+      debounceMs: options.debounceMs ?? DEFAULT_WATCH_DEBOUNCE_MS,
+      hooks: {
+        ...(options.onReload ? { onReload: options.onReload } : {}),
+        ...(options.onError ? { onError: options.onError } : {}),
+      },
+    });
+  }
+
+  get currentSnapshot(): WorkflowSnapshot {
+    return this.#currentSnapshot;
+  }
+
+  start(): this {
+    if (this.#watcher) {
+      return this;
+    }
+
+    this.#watcher = watch(this.workflowPath, () => {
+      this.#scheduleReload();
+    });
+
+    this.#watcher.on("error", (error) => {
+      void this.#emitError({
+        reason: "filesystem_event",
+        currentSnapshot: this.#currentSnapshot,
+        error,
+      });
+    });
+
+    return this;
+  }
+
+  async reload(
+    reason: WorkflowReloadReason = "manual",
+  ): Promise<WorkflowReloadResult> {
+    if (this.#reloadInFlight) {
+      if (reason === "filesystem_event") {
+        this.#reloadQueued = true;
+      }
+
+      return this.#reloadInFlight;
+    }
+
+    const operation = this.#performReload(reason).finally(() => {
+      this.#reloadInFlight = null;
+
+      if (this.#reloadQueued) {
+        this.#reloadQueued = false;
+        void this.reload("filesystem_event");
+      }
+    });
+
+    this.#reloadInFlight = operation;
+    return operation;
+  }
+
+  async close(): Promise<void> {
+    if (this.#debounceTimer) {
+      clearTimeout(this.#debounceTimer);
+      this.#debounceTimer = null;
+    }
+
+    if (this.#watcher) {
+      this.#watcher.close();
+      this.#watcher = null;
+    }
+
+    if (this.#reloadInFlight) {
+      await this.#reloadInFlight;
+    }
+  }
+
+  async #performReload(
+    reason: WorkflowReloadReason,
+  ): Promise<WorkflowReloadResult> {
+    try {
+      const snapshot = await loadWorkflowSnapshot(
+        this.workflowPath,
+        this.#environment,
+      );
+      const previousSnapshot = this.#currentSnapshot;
+      this.#currentSnapshot = snapshot;
+
+      const result = {
+        ok: true,
+        reason,
+        previousSnapshot,
+        snapshot,
+      } satisfies WorkflowReloadResult;
+
+      await this.#hooks.onReload?.({
+        reason,
+        previousSnapshot,
+        snapshot,
+      });
+
+      return result;
+    } catch (error) {
+      const result = {
+        ok: false,
+        reason,
+        currentSnapshot: this.#currentSnapshot,
+        error,
+      } satisfies WorkflowReloadResult;
+
+      await this.#emitError(result);
+      return result;
+    }
+  }
+
+  #scheduleReload(): void {
+    if (this.#debounceTimer) {
+      clearTimeout(this.#debounceTimer);
+    }
+
+    this.#debounceTimer = setTimeout(() => {
+      this.#debounceTimer = null;
+      void this.reload("filesystem_event");
+    }, this.#debounceMs);
+  }
+
+  async #emitError(result: {
+    reason: WorkflowReloadReason;
+    currentSnapshot: WorkflowSnapshot;
+    error: unknown;
+  }): Promise<void> {
+    await this.#hooks.onError?.(result);
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ export * from "./config/defaults.js";
 export * from "./config/config-resolver.js";
 export * from "./config/types.js";
 export * from "./config/workflow-loader.js";
+export * from "./config/workflow-watch.js";
 export * from "./domain/model.js";
 export * from "./errors/codes.js";
 export * from "./logging/fields.js";

--- a/tests/config/workflow-watch.test.ts
+++ b/tests/config/workflow-watch.test.ts
@@ -1,0 +1,186 @@
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { WorkflowLoaderError } from "../../src/config/workflow-loader.js";
+import {
+  WorkflowWatcher,
+  loadWorkflowSnapshot,
+} from "../../src/config/workflow-watch.js";
+import { ERROR_CODES } from "../../src/errors/codes.js";
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.allSettled(
+    tempDirs.splice(0).map(async (directory) => {
+      await import("node:fs/promises").then(({ rm }) =>
+        rm(directory, { recursive: true, force: true }),
+      );
+    }),
+  );
+});
+
+describe("workflow-watch", () => {
+  it("loads a workflow snapshot with resolved config and dispatch validation", async () => {
+    const workflowPath = await writeWorkflow(`---
+tracker:
+  kind: linear
+  api_key: token
+  project_slug: ENG
+polling:
+  interval_ms: 15000
+---
+Ship it.
+`);
+
+    const snapshot = await loadWorkflowSnapshot(workflowPath, {});
+
+    expect(snapshot.definition.workflowPath).toBe(workflowPath);
+    expect(snapshot.config.polling.intervalMs).toBe(15_000);
+    expect(snapshot.dispatchValidation).toEqual({ ok: true });
+  });
+
+  it("keeps the last known good snapshot when reload parsing fails", async () => {
+    const workflowPath = await writeWorkflow(`---
+tracker:
+  kind: linear
+  api_key: token
+  project_slug: ENG
+---
+Prompt v1
+`);
+    const onError = vi.fn();
+    const watcher = await WorkflowWatcher.create({
+      workflowPath,
+      environment: {},
+      onError,
+    });
+
+    await writeFile(
+      workflowPath,
+      `---
+tracker: [broken
+---
+Prompt v2
+`,
+      "utf8",
+    );
+
+    const result = await watcher.reload();
+
+    expect(result.ok).toBe(false);
+    expect(watcher.currentSnapshot.definition.promptTemplate).toBe("Prompt v1");
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError.mock.calls[0]?.[0]).toMatchObject({
+      reason: "manual",
+      currentSnapshot: watcher.currentSnapshot,
+      error: expect.objectContaining<Partial<WorkflowLoaderError>>({
+        code: ERROR_CODES.workflowParseError,
+      }),
+    });
+
+    await watcher.close();
+  });
+
+  it("updates the current snapshot when reload changes dispatch readiness", async () => {
+    const workflowPath = await writeWorkflow(`---
+tracker:
+  kind: linear
+  api_key: token
+  project_slug: ENG
+---
+Prompt v1
+`);
+    const onReload = vi.fn();
+    const watcher = await WorkflowWatcher.create({
+      workflowPath,
+      environment: {},
+      onReload,
+    });
+
+    await writeFile(
+      workflowPath,
+      `---
+tracker:
+  kind: linear
+---
+Prompt v2
+`,
+      "utf8",
+    );
+
+    const result = await watcher.reload();
+
+    expect(result).toMatchObject({
+      ok: true,
+      reason: "manual",
+    });
+    expect(watcher.currentSnapshot.definition.promptTemplate).toBe("Prompt v2");
+    expect(watcher.currentSnapshot.dispatchValidation).toEqual({
+      ok: false,
+      error: {
+        code: ERROR_CODES.trackerCredentialsMissing,
+        message: "tracker.api_key must be configured before dispatch.",
+      },
+    });
+    expect(onReload).toHaveBeenCalledTimes(1);
+
+    await watcher.close();
+  });
+
+  it("reloads automatically when the workflow file changes on disk", async () => {
+    const workflowPath = await writeWorkflow(`---
+tracker:
+  kind: linear
+  api_key: token
+  project_slug: ENG
+---
+Prompt v1
+`);
+    const onReload = vi.fn();
+    const watcher = await WorkflowWatcher.create({
+      workflowPath,
+      environment: {},
+      debounceMs: 25,
+      onReload,
+    });
+    watcher.start();
+
+    await writeFile(
+      workflowPath,
+      `---
+tracker:
+  kind: linear
+  api_key: token
+  project_slug: ENG
+polling:
+  interval_ms: 20000
+---
+Prompt v2
+`,
+      "utf8",
+    );
+
+    await vi.waitFor(() => {
+      expect(watcher.currentSnapshot.definition.promptTemplate).toBe(
+        "Prompt v2",
+      );
+    });
+
+    expect(watcher.currentSnapshot.config.polling.intervalMs).toBe(20_000);
+    expect(onReload).toHaveBeenCalled();
+
+    await watcher.close();
+  });
+});
+
+async function writeWorkflow(content: string): Promise<string> {
+  const directory = await mkdtemp(join(tmpdir(), "symphony-task5-"));
+  tempDirs.push(directory);
+  const workflowPath = join(directory, "WORKFLOW.md");
+  await writeFile(workflowPath, content, "utf8");
+  return workflowPath;
+}


### PR DESCRIPTION
## Problem statement
Implement Task 5 from the local implementation plan: watch `WORKFLOW.md`, reload workflow config and prompt at runtime, and preserve the last known good configuration when reload fails.

## Scope
- add workflow snapshot loading with resolved config and dispatch validation
- add a workflow watcher with manual and filesystem-triggered reload paths
- preserve the current effective snapshot when workflow parsing/loading fails
- add tests for snapshot loading, reload fallback, dispatch-readiness changes, and filesystem watch behavior

## References
- IMPLEMENTATION_PLAN.md Task 5
- SPEC.upstream.md Section 6.2
- SPEC.upstream.md Section 6.3

## Test evidence
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`

## Notes
- No screenshots or generated artifacts for this change.