### PR TITLE
Add CLI groundwork for task 16

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "type": "module",
+  "bin": {
+    "symphony": "./dist/cli/main.js"
+  },
   "engines": {
     "node": ">=22.0.0",
     "pnpm": ">=10.0.0"
@@ -10,6 +13,7 @@
   "packageManager": "pnpm@10.30.2",
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
+    "start": "node dist/cli/main.js",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -1,0 +1,270 @@
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+import type { ResolvedWorkflowConfig } from "../config/types.js";
+import { resolveWorkflowConfig } from "../config/config-resolver.js";
+import { WORKFLOW_FILENAME } from "../config/defaults.js";
+import { loadWorkflowDefinition } from "../config/workflow-loader.js";
+import { ERROR_CODES } from "../errors/codes.js";
+
+export const CLI_ACKNOWLEDGEMENT_FLAG =
+  "--acknowledge-high-trust-preview";
+
+export interface CliOptions {
+  workflowPath: string | null;
+  logsRoot: string | null;
+  port: number | null;
+  acknowledged: boolean;
+  help: boolean;
+}
+
+export interface CliRuntimeSettings {
+  config: ResolvedWorkflowConfig;
+  logsRoot: string | null;
+}
+
+export interface CliHost {
+  waitForExit(): Promise<number | void>;
+  shutdown?(): Promise<void>;
+}
+
+export interface StartCliHostInput {
+  options: CliOptions;
+  runtime: CliRuntimeSettings;
+}
+
+export interface CliIo {
+  stdout(message: string): void;
+  stderr(message: string): void;
+}
+
+export interface CliDependencies {
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+  io?: CliIo;
+  loadWorkflowDefinition?: typeof loadWorkflowDefinition;
+  resolveWorkflowConfig?: typeof resolveWorkflowConfig;
+  startHost?: (input: StartCliHostInput) => Promise<CliHost>;
+}
+
+export class CliUsageError extends Error {
+  readonly code = ERROR_CODES.cliStartupFailed;
+
+  constructor(message: string) {
+    super(message);
+    this.name = "CliUsageError";
+  }
+}
+
+export function parseCliArgs(argv: readonly string[]): CliOptions {
+  let workflowPath: string | null = null;
+  let logsRoot: string | null = null;
+  let port: number | null = null;
+  let acknowledged = false;
+  let help = false;
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (token === undefined) {
+      continue;
+    }
+
+    if (!token.startsWith("-")) {
+      if (workflowPath !== null) {
+        throw new CliUsageError(
+          "CLI accepts at most one positional workflow path argument.",
+        );
+      }
+
+      workflowPath = token;
+      continue;
+    }
+
+    if (token === "--help" || token === "-h") {
+      help = true;
+      continue;
+    }
+
+    if (token === CLI_ACKNOWLEDGEMENT_FLAG) {
+      acknowledged = true;
+      continue;
+    }
+
+    if (token === "--logs-root") {
+      logsRoot = readValueFlag(argv, ++index, "--logs-root");
+      continue;
+    }
+
+    if (token.startsWith("--logs-root=")) {
+      logsRoot = token.slice("--logs-root=".length);
+      ensureFlagValue(logsRoot, "--logs-root");
+      continue;
+    }
+
+    if (token === "--port") {
+      port = parsePort(readValueFlag(argv, ++index, "--port"));
+      continue;
+    }
+
+    if (token.startsWith("--port=")) {
+      port = parsePort(token.slice("--port=".length));
+      continue;
+    }
+
+    throw new CliUsageError(`Unknown CLI argument: ${token}`);
+  }
+
+  return {
+    workflowPath,
+    logsRoot,
+    port,
+    acknowledged,
+    help,
+  };
+}
+
+export function applyCliOverrides(
+  config: ResolvedWorkflowConfig,
+  options: CliOptions,
+  cwd = process.cwd(),
+): CliRuntimeSettings {
+  return {
+    config: {
+      ...config,
+      server: {
+        ...config.server,
+        port: options.port ?? config.server.port,
+      },
+    },
+    logsRoot: options.logsRoot ? resolve(cwd, options.logsRoot) : null,
+  };
+}
+
+export async function runCli(
+  argv: readonly string[],
+  dependencies: CliDependencies = {},
+): Promise<number> {
+  const cwd = dependencies.cwd ?? process.cwd();
+  const env = dependencies.env ?? process.env;
+  const io = dependencies.io ?? {
+    stdout: (message: string) => process.stdout.write(message),
+    stderr: (message: string) => process.stderr.write(message),
+  };
+  const loadWorkflow =
+    dependencies.loadWorkflowDefinition ?? loadWorkflowDefinition;
+  const resolveConfig =
+    dependencies.resolveWorkflowConfig ?? resolveWorkflowConfig;
+  const startHost =
+    dependencies.startHost ??
+    (async () => ({
+      async waitForExit() {
+        return 0;
+      },
+    }));
+
+  let options: CliOptions;
+  try {
+    options = parseCliArgs(argv);
+  } catch (error) {
+    io.stderr(`${formatCliError(error)}\n${renderUsage()}`);
+    return 1;
+  }
+
+  if (options.help) {
+    io.stdout(renderUsage());
+    return 0;
+  }
+
+  if (!options.acknowledged) {
+    io.stderr(
+      `Refusing to start without ${CLI_ACKNOWLEDGEMENT_FLAG}. ` +
+        "Symphony is a high-trust preview intended for trusted environments.\n",
+    );
+    return 1;
+  }
+
+  try {
+    const workflowPath =
+      options.workflowPath === null
+        ? resolve(cwd, WORKFLOW_FILENAME)
+        : resolve(cwd, options.workflowPath);
+    const workflow = await loadWorkflow(workflowPath);
+    const config = resolveConfig(workflow, env);
+    const runtime = applyCliOverrides(config, options, cwd);
+    const host = await startHost({
+      options,
+      runtime,
+    });
+    const exitCode = await host.waitForExit();
+
+    if (typeof exitCode === "number" && exitCode !== 0) {
+      io.stderr(`Symphony host exited abnormally with code ${exitCode}.\n`);
+      return exitCode;
+    }
+
+    return 0;
+  } catch (error) {
+    io.stderr(`${formatCliError(error)}\n`);
+    return 1;
+  }
+}
+
+export async function main(): Promise<void> {
+  const exitCode = await runCli(process.argv.slice(2));
+  process.exitCode = exitCode;
+}
+
+function readValueFlag(
+  argv: readonly string[],
+  index: number,
+  flag: string,
+): string {
+  const value = argv[index];
+  ensureFlagValue(value, flag);
+  return value;
+}
+
+function ensureFlagValue(
+  value: string | undefined,
+  flag: string,
+): asserts value is string {
+  if (!value || value.startsWith("-")) {
+    throw new CliUsageError(`Missing value for ${flag}.`);
+  }
+}
+
+function parsePort(rawPort: string): number {
+  if (!/^\d+$/.test(rawPort.trim())) {
+    throw new CliUsageError(`Invalid value for --port: ${rawPort}`);
+  }
+
+  return Number.parseInt(rawPort, 10);
+}
+
+function formatCliError(error: unknown): string {
+  if (error instanceof Error && error.message) {
+    return error.message;
+  }
+
+  return "Symphony failed to start.";
+}
+
+function renderUsage(): string {
+  return [
+    "Usage: symphony [path-to-WORKFLOW.md] [options]",
+    "",
+    "Options:",
+    `  ${CLI_ACKNOWLEDGEMENT_FLAG}  required before startup`,
+    "  --logs-root <path>           override the logs root directory",
+    "  --port <number>              override the HTTP server port",
+    "  --help                       show this help text",
+    "",
+  ].join("\n");
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  void main();
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./agent/prompt-builder.js";
+export * from "./cli/main.js";
 export * from "./config/defaults.js";
 export * from "./config/config-resolver.js";
 export * from "./config/types.js";

--- a/tests/cli/main.test.ts
+++ b/tests/cli/main.test.ts
@@ -1,0 +1,245 @@
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { describe, expect, it, vi } from "vitest";
+
+import type { ResolvedWorkflowConfig } from "../../src/config/types.js";
+import {
+  CLI_ACKNOWLEDGEMENT_FLAG,
+  applyCliOverrides,
+  parseCliArgs,
+  runCli,
+} from "../../src/cli/main.js";
+
+describe("cli", () => {
+  it("parses the workflow path and CLI override flags", () => {
+    expect(
+      parseCliArgs([
+        "config/WORKFLOW.md",
+        "--logs-root",
+        "./logs",
+        "--port=8080",
+        CLI_ACKNOWLEDGEMENT_FLAG,
+      ]),
+    ).toEqual({
+      workflowPath: "config/WORKFLOW.md",
+      logsRoot: "./logs",
+      port: 8080,
+      acknowledged: true,
+      help: false,
+    });
+  });
+
+  it("rejects unknown flags and duplicate positional arguments", () => {
+    expect(() => parseCliArgs(["--unknown"])).toThrowError(
+      "Unknown CLI argument: --unknown",
+    );
+    expect(() => parseCliArgs(["one.md", "two.md"])).toThrowError(
+      "CLI accepts at most one positional workflow path argument.",
+    );
+  });
+
+  it("applies CLI overrides with port precedence and absolute logs root", () => {
+    const runtime = applyCliOverrides(
+      createConfig({
+        server: {
+          port: 3000,
+        },
+      }),
+      {
+        workflowPath: null,
+        logsRoot: "./runtime-logs",
+        port: 8080,
+        acknowledged: true,
+        help: false,
+      },
+      "/repo",
+    );
+
+    expect(runtime.config.server.port).toBe(8080);
+    expect(runtime.logsRoot).toBe("/repo/runtime-logs");
+  });
+
+  it("defaults to loading ./WORKFLOW.md from cwd when no workflow path is given", async () => {
+    const workspace = await mkdtemp(join(tmpdir(), "symphony-task16-cli-"));
+    const workflowPath = join(workspace, "WORKFLOW.md");
+    await writeFile(workflowPath, "Prompt body\n", "utf8");
+
+    const startHost = vi.fn(async () => ({
+      async waitForExit() {
+        return 0;
+      },
+    }));
+
+    const exitCode = await runCli([CLI_ACKNOWLEDGEMENT_FLAG], {
+      cwd: workspace,
+      env: {},
+      startHost,
+    });
+
+    expect(exitCode).toBe(0);
+    expect(startHost).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runtime: expect.objectContaining({
+          config: expect.objectContaining({
+            workflowPath,
+          }),
+        }),
+      }),
+    );
+  });
+
+  it("returns nonzero and skips startup when acknowledgement is missing", async () => {
+    const stderr = vi.fn();
+    const startHost = vi.fn();
+
+    const exitCode = await runCli([], {
+      io: {
+        stdout: vi.fn(),
+        stderr,
+      },
+      startHost,
+    });
+
+    expect(exitCode).toBe(1);
+    expect(startHost).not.toHaveBeenCalled();
+    expect(stderr).toHaveBeenCalledWith(
+      expect.stringContaining(CLI_ACKNOWLEDGEMENT_FLAG),
+    );
+  });
+
+  it("returns nonzero when the workflow file is missing", async () => {
+    const stderr = vi.fn();
+
+    const exitCode = await runCli(
+      ["missing.md", CLI_ACKNOWLEDGEMENT_FLAG],
+      {
+        io: {
+          stdout: vi.fn(),
+          stderr,
+        },
+      },
+    );
+
+    expect(exitCode).toBe(1);
+    expect(stderr).toHaveBeenCalledWith(
+      expect.stringContaining("Unable to read workflow file"),
+    );
+  });
+
+  it("returns success when the host starts and shuts down normally", async () => {
+    const startHost = vi.fn(async () => ({
+      async waitForExit() {
+        return 0;
+      },
+    }));
+
+    const exitCode = await runCli([CLI_ACKNOWLEDGEMENT_FLAG], {
+      env: {},
+      loadWorkflowDefinition: vi.fn(async () => ({
+        workflowPath: "/repo/WORKFLOW.md",
+        config: {},
+        promptTemplate: "Prompt",
+      })),
+      startHost,
+    });
+
+    expect(exitCode).toBe(0);
+    expect(startHost).toHaveBeenCalledOnce();
+  });
+
+  it("returns nonzero when startup fails or the host exits abnormally", async () => {
+    const stderr = vi.fn();
+
+    const startupFailure = await runCli([CLI_ACKNOWLEDGEMENT_FLAG], {
+      io: {
+        stdout: vi.fn(),
+        stderr,
+      },
+      env: {},
+      loadWorkflowDefinition: vi.fn(async () => ({
+        workflowPath: "/repo/WORKFLOW.md",
+        config: {},
+        promptTemplate: "Prompt",
+      })),
+      startHost: vi.fn(async () => {
+        throw new Error("boom");
+      }),
+    });
+
+    const abnormalExit = await runCli([CLI_ACKNOWLEDGEMENT_FLAG], {
+      io: {
+        stdout: vi.fn(),
+        stderr,
+      },
+      env: {},
+      loadWorkflowDefinition: vi.fn(async () => ({
+        workflowPath: "/repo/WORKFLOW.md",
+        config: {},
+        promptTemplate: "Prompt",
+      })),
+      startHost: vi.fn(async () => ({
+        async waitForExit() {
+          return 3;
+        },
+      })),
+    });
+
+    expect(startupFailure).toBe(1);
+    expect(abnormalExit).toBe(3);
+    expect(stderr).toHaveBeenCalledWith(expect.stringContaining("boom"));
+    expect(stderr).toHaveBeenCalledWith(
+      "Symphony host exited abnormally with code 3.\n",
+    );
+  });
+});
+
+function createConfig(
+  overrides: Partial<ResolvedWorkflowConfig> = {},
+): ResolvedWorkflowConfig {
+  return {
+    workflowPath: "/repo/WORKFLOW.md",
+    promptTemplate: "Prompt",
+    tracker: {
+      kind: "linear",
+      endpoint: "https://api.linear.app/graphql",
+      apiKey: "token",
+      projectSlug: "ENG",
+      activeStates: ["Todo"],
+      terminalStates: ["Done"],
+    },
+    polling: {
+      intervalMs: 30_000,
+    },
+    workspace: {
+      root: "/tmp/symphony",
+    },
+    hooks: {
+      afterCreate: null,
+      beforeRun: null,
+      afterRun: null,
+      beforeRemove: null,
+      timeoutMs: 60_000,
+    },
+    agent: {
+      maxConcurrentAgents: 10,
+      maxTurns: 20,
+      maxRetryBackoffMs: 300_000,
+      maxConcurrentAgentsByState: {},
+    },
+    codex: {
+      command: "codex app-server",
+      approvalPolicy: null,
+      threadSandbox: null,
+      turnSandboxPolicy: null,
+      turnTimeoutMs: 3_600_000,
+      readTimeoutMs: 5_000,
+      stallTimeoutMs: 300_000,
+    },
+    server: {
+      port: null,
+    },
+    ...overrides,
+  };
+}


### PR DESCRIPTION
## Problem

Task 16 is in the current wave, but the repository baseline does not yet include the real host/orchestrator/HTTP server pieces needed to fully satisfy the CLI spec.

This PR lands the CLI groundwork now so later work can wire it into the real runtime without redoing argument parsing and lifecycle tests.

## Scope

- add a dedicated CLI entrypoint and argument parsing
- support workflow path selection, --logs-root, --port, and explicit acknowledgement gating
- add CLI-focused tests for startup and exit semantics
- expose the CLI entrypoint through package metadata

## Test evidence

- `pnpm typecheck`
- `pnpm test`

## TODO before task 16 can be considered spec-complete

- wire the CLI host to the real runtime instead of the current injectable shell
- make `--port` start the actual HTTP observability server and honor precedence against `server.port` in the real host path
- connect normal and abnormal process exit handling to the real orchestrator/host lifecycle
- re-validate the finished behavior against SPEC sections 13.7 and 17.7
