### PR TITLE
Expand conformance test coverage

### DIFF
--- a/src/tracker/linear-client.ts
+++ b/src/tracker/linear-client.ts
@@ -1,9 +1,9 @@
-import type { Issue } from "../domain/model.js";
-import { ERROR_CODES } from "../errors/codes.js";
 import {
   DEFAULT_LINEAR_NETWORK_TIMEOUT_MS,
   DEFAULT_LINEAR_PAGE_SIZE,
 } from "../config/defaults.js";
+import type { Issue } from "../domain/model.js";
+import { ERROR_CODES } from "../errors/codes.js";
 import { TrackerError, toTrackerRequestError } from "./errors.js";
 import {
   normalizeLinearIssue,

--- a/src/tracker/linear-normalize.ts
+++ b/src/tracker/linear-normalize.ts
@@ -120,9 +120,7 @@ function normalizePriority(value: unknown): number | null {
   return typeof value === "number" && Number.isInteger(value) ? value : null;
 }
 
-function normalizeLabels(
-  labels: LinearIssueNode["labels"],
-): string[] {
+function normalizeLabels(labels: LinearIssueNode["labels"]): string[] {
   const nodes = labels?.nodes;
   if (!Array.isArray(nodes)) {
     return [];
@@ -152,13 +150,16 @@ function normalizeBlockedBy(
 }
 
 function normalizeBlocker(
-  sourceIssue: {
-    id?: unknown;
-    identifier?: unknown;
-    state?: {
-      name?: unknown;
-    } | null;
-  } | null | undefined,
+  sourceIssue:
+    | {
+        id?: unknown;
+        identifier?: unknown;
+        state?: {
+          name?: unknown;
+        } | null;
+      }
+    | null
+    | undefined,
 ): BlockerRef {
   return {
     id: typeof sourceIssue?.id === "string" ? sourceIssue.id : null,

--- a/src/workspace/workspace-manager.ts
+++ b/src/workspace/workspace-manager.ts
@@ -1,4 +1,5 @@
 import { promises as fs } from "node:fs";
+import { join } from "node:path";
 
 import type { Workspace } from "../domain/model.js";
 import { ERROR_CODES } from "../errors/codes.js";
@@ -25,6 +26,8 @@ export interface WorkspaceManagerOptions {
 }
 
 export class WorkspaceManager {
+  static readonly TEMP_ARTIFACT_PATHS = ["tmp", ".elixir_ls"] as const;
+
   readonly root: string;
   readonly #fs: FileSystemLike;
   readonly #hooks: WorkspaceHookRunner | null;
@@ -46,6 +49,7 @@ export class WorkspaceManager {
     try {
       await this.#fs.mkdir(workspaceRoot, { recursive: true });
       const createdNow = await this.#ensureWorkspaceDirectory(workspacePath);
+      await this.#removeTemporaryArtifacts(workspacePath);
       const workspace = {
         path: workspacePath,
         workspaceKey,
@@ -146,6 +150,17 @@ export class WorkspaceManager {
 
       throw error;
     }
+  }
+
+  async #removeTemporaryArtifacts(workspacePath: string): Promise<void> {
+    await Promise.all(
+      WorkspaceManager.TEMP_ARTIFACT_PATHS.map(async (relativePath) => {
+        await this.#fs.rm(join(workspacePath, relativePath), {
+          force: true,
+          recursive: true,
+        });
+      }),
+    );
   }
 }
 

--- a/tests/codex/app-server-client.test.ts
+++ b/tests/codex/app-server-client.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -186,6 +186,124 @@ describe("CodexAppServerClient", () => {
 
     await client.close();
   });
+
+  it("sends the expected startup handshake payloads and advertises tools", async () => {
+    const workspace = await createWorkspace();
+    const capturePath = join(workspace, "requests.json");
+    const client = createClient("capture-startup", workspace, [], {
+      command: `${process.execPath} "${fixturePath}" capture-startup "${capturePath}"`,
+      capabilities: {
+        roots: ["workspace"],
+      },
+      tools: [
+        {
+          name: "linear_graphql",
+          description: "Run one GraphQL operation",
+        },
+      ],
+    });
+
+    await expect(
+      client.startSession({
+        prompt: "Start",
+        title: "ABC-123: Example",
+      }),
+    ).resolves.toMatchObject({
+      status: "completed",
+      threadId: "thread-1",
+      turnId: "turn-1",
+    });
+
+    const requests = JSON.parse(await readFile(capturePath, "utf8")) as Array<{
+      id?: number;
+      method?: string;
+      params?: Record<string, unknown>;
+    }>;
+
+    expect(
+      requests.map((request) => request.method ?? `response:${request.id}`),
+    ).toEqual(["initialize", "initialized", "thread/start", "turn/start"]);
+    expect(requests[0]?.params).toEqual({
+      clientInfo: {
+        name: "symphony-ts",
+        version: "0.1.0",
+      },
+      capabilities: {
+        roots: ["workspace"],
+      },
+    });
+    expect(requests[2]?.params).toMatchObject({
+      approvalPolicy: "full-auto",
+      sandbox: "workspace-write",
+      cwd: workspace,
+      tools: [
+        {
+          name: "linear_graphql",
+          description: "Run one GraphQL operation",
+        },
+      ],
+    });
+    expect(requests[3]?.params).toMatchObject({
+      threadId: "thread-1",
+      cwd: workspace,
+      title: "ABC-123: Example",
+      approvalPolicy: "full-auto",
+      sandboxPolicy: {
+        type: "workspace-write",
+      },
+      input: [{ type: "text", text: "Start" }],
+    });
+
+    await client.close();
+  });
+
+  it("launches the command through bash -lc", async () => {
+    const workspace = await createWorkspace();
+    const shellMarkerPath = join(workspace, "shell.txt");
+    const scriptPath = join(workspace, "server.mjs");
+    await writeFile(
+      scriptPath,
+      [
+        "import readline from 'node:readline';",
+        "const rl = readline.createInterface({ input: process.stdin, crlfDelay: Infinity });",
+        "rl.on('line', (line) => {",
+        "  const message = JSON.parse(line);",
+        "  if (message.method === 'initialize') {",
+        "    process.stdout.write(JSON.stringify({ id: message.id, result: { serverInfo: { name: 'capture' } } }) + '\\n');",
+        "    return;",
+        "  }",
+        "  if (message.method === 'thread/start') {",
+        "    process.stdout.write(JSON.stringify({ id: message.id, result: { thread: { id: 'thread-1' } } }) + '\\n');",
+        "    return;",
+        "  }",
+        "  if (message.method === 'turn/start') {",
+        "    process.stdout.write(JSON.stringify({ id: message.id, result: { turn: { id: 'turn-1' } } }) + '\\n');",
+        "    setTimeout(() => {",
+        "      process.stdout.write(JSON.stringify({ method: 'turn/completed', params: { message: 'ok' } }) + '\\n');",
+        "    }, 10);",
+        "  }",
+        "});",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const client = createClient("happy", workspace, [], {
+      command: `printf '%s' \"$0\" > "${shellMarkerPath}"; exec ${process.execPath} "${scriptPath}"`,
+    });
+
+    await expect(
+      client.startSession({
+        prompt: "Start",
+        title: "ABC-123: Example",
+      }),
+    ).resolves.toMatchObject({
+      status: "completed",
+      sessionId: "thread-1-turn-1",
+    });
+
+    await expect(readFile(shellMarkerPath, "utf8")).resolves.toBe("bash");
+    await client.close();
+  });
 });
 
 function createClient(
@@ -193,22 +311,34 @@ function createClient(
   workspace: string,
   events: CodexClientEvent[],
   overrides?: Partial<{
+    command: string;
+    capabilities: Record<string, unknown>;
     readTimeoutMs: number;
     turnTimeoutMs: number;
     stallTimeoutMs: number;
+    tools: Array<{
+      name: string;
+      description?: string;
+      inputSchema?: Record<string, unknown>;
+    }>;
   }>,
 ): CodexAppServerClient {
   return new CodexAppServerClient({
-    command: `${process.execPath} "${fixturePath}" ${scenario}`,
+    command:
+      overrides?.command ?? `${process.execPath} "${fixturePath}" ${scenario}`,
     cwd: workspace,
     approvalPolicy: "full-auto",
     threadSandbox: "workspace-write",
     turnSandboxPolicy: {
       type: "workspace-write",
     },
-    readTimeoutMs: overrides?.readTimeoutMs ?? 250,
-    turnTimeoutMs: overrides?.turnTimeoutMs ?? 500,
+    readTimeoutMs: overrides?.readTimeoutMs ?? 1_000,
+    turnTimeoutMs: overrides?.turnTimeoutMs ?? 1_000,
     stallTimeoutMs: overrides?.stallTimeoutMs ?? 1_000,
+    ...(overrides?.capabilities === undefined
+      ? {}
+      : { capabilities: overrides.capabilities }),
+    ...(overrides?.tools === undefined ? {} : { tools: overrides.tools }),
     onEvent: (event) => {
       events.push(event);
     },

--- a/tests/config/config-resolver.test.ts
+++ b/tests/config/config-resolver.test.ts
@@ -1,3 +1,4 @@
+import { homedir } from "node:os";
 import { join } from "node:path";
 
 import { describe, expect, it } from "vitest";
@@ -139,6 +140,27 @@ describe("config-resolver", () => {
     );
 
     expect(resolved.tracker.apiKey).toBe("canonical-secret");
+  });
+
+  it("expands ~ and env-backed workspace roots", () => {
+    const resolved = resolveWorkflowConfig(
+      {
+        workflowPath: "/repo/WORKFLOW.md",
+        promptTemplate: "Prompt",
+        config: {
+          workspace: {
+            root: "$WORKSPACE_ROOT",
+          },
+        },
+      },
+      {
+        WORKSPACE_ROOT: "~/symphony/workspaces",
+      },
+    );
+
+    expect(resolved.workspace.root).toBe(
+      join(homedir(), "symphony", "workspaces"),
+    );
   });
 
   it("blocks dispatch when required tracker settings are missing", () => {

--- a/tests/config/workflow-loader.test.ts
+++ b/tests/config/workflow-loader.test.ts
@@ -2,7 +2,7 @@ import { mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   WorkflowLoaderError,
@@ -13,6 +13,10 @@ import {
 import { ERROR_CODES } from "../../src/errors/codes.js";
 
 describe("workflow-loader", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("parses YAML front matter and trims the prompt body", () => {
     const workflow = parseWorkflowContent(`---
 tracker:
@@ -91,6 +95,12 @@ Prompt`);
     expect(workflow.workflowPath).toBe(workflowPath);
     expect(workflow.promptTemplate).toBe("Prompt body");
     expect(resolveWorkflowPath(workflowPath)).toBe(workflowPath);
+  });
+
+  it("resolves to cwd/WORKFLOW.md when no explicit workflow path is provided", () => {
+    vi.spyOn(process, "cwd").mockReturnValue("/repo/current");
+
+    expect(resolveWorkflowPath()).toBe("/repo/current/WORKFLOW.md");
   });
 
   it("returns a typed missing-workflow error when the file does not exist", async () => {

--- a/tests/fixtures/codex-fake-server.mjs
+++ b/tests/fixtures/codex-fake-server.mjs
@@ -1,8 +1,9 @@
-import { realpathSync } from "node:fs";
+import { realpathSync, writeFileSync } from "node:fs";
 import process from "node:process";
 import readline from "node:readline";
 
 const scenario = process.argv[2] ?? "happy";
+const capturePath = process.argv[3] ?? null;
 const requests = [];
 let turnCount = 0;
 
@@ -85,6 +86,19 @@ async function handleMessage(message) {
     });
 
     if (scenario === "turn-timeout") {
+      return;
+    }
+
+    if (scenario === "capture-startup") {
+      captureRequests();
+      setTimeout(() => {
+        writeJson({
+          method: "turn/completed",
+          params: {
+            message: "Captured startup",
+          },
+        });
+      }, 10);
       return;
     }
 
@@ -194,6 +208,14 @@ async function handleMessage(message) {
       });
     }, 10);
   }
+}
+
+function captureRequests() {
+  if (!capturePath) {
+    throw new Error("capture-startup scenario requires a capture path");
+  }
+
+  writeFileSync(capturePath, JSON.stringify(requests, null, 2), "utf8");
 }
 
 function writeJson(message) {

--- a/tests/tracker/linear-client.test.ts
+++ b/tests/tracker/linear-client.test.ts
@@ -1,12 +1,12 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+import { ERROR_CODES } from "../../src/errors/codes.js";
 import {
   LINEAR_CANDIDATE_ISSUES_QUERY,
   LINEAR_ISSUE_STATES_BY_IDS_QUERY,
   LinearTrackerClient,
-  TrackerError,
+  type TrackerError,
 } from "../../src/index.js";
-import { ERROR_CODES } from "../../src/errors/codes.js";
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -140,7 +140,9 @@ describe("LinearTrackerClient", () => {
       fetchFn: vi.fn<typeof fetch>(),
     });
 
-    await expect(missingApiKeyClient.fetchIssueStatesByIds(["1"])).rejects.toThrow(
+    await expect(
+      missingApiKeyClient.fetchIssueStatesByIds(["1"]),
+    ).rejects.toThrow(
       expect.objectContaining<Partial<TrackerError>>({
         code: ERROR_CODES.missingTrackerApiKey,
       }),
@@ -154,9 +156,9 @@ describe("LinearTrackerClient", () => {
 
   it("maps non-200, GraphQL errors, malformed payloads, and missing cursors", async () => {
     const non200Client = createClient({
-      fetchFn: vi.fn<typeof fetch>().mockResolvedValue(
-        new Response("boom", { status: 500 }),
-      ),
+      fetchFn: vi
+        .fn<typeof fetch>()
+        .mockResolvedValue(new Response("boom", { status: 500 })),
     });
     await expect(non200Client.fetchCandidateIssues()).rejects.toThrow(
       expect.objectContaining<Partial<TrackerError>>({
@@ -223,7 +225,9 @@ describe("LinearTrackerClient", () => {
 
   it("maps transport failures to linear_api_request", async () => {
     const client = createClient({
-      fetchFn: vi.fn<typeof fetch>().mockRejectedValue(new Error("network down")),
+      fetchFn: vi
+        .fn<typeof fetch>()
+        .mockRejectedValue(new Error("network down")),
     });
 
     await expect(client.fetchCandidateIssues()).rejects.toThrow(

--- a/tests/tracker/linear-normalize.test.ts
+++ b/tests/tracker/linear-normalize.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from "vitest";
 
+import { ERROR_CODES } from "../../src/errors/codes.js";
 import {
+  type TrackerError,
   normalizeLinearIssue,
   normalizeLinearIssueState,
-  TrackerError,
 } from "../../src/index.js";
-import { ERROR_CODES } from "../../src/errors/codes.js";
 
 describe("linear-normalize", () => {
   it("normalizes labels, blockers, integer priority, and timestamps", () => {

--- a/tests/workspace/workspace-manager.test.ts
+++ b/tests/workspace/workspace-manager.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readdir, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -73,6 +73,23 @@ describe("WorkspaceManager", () => {
     await manager.createForIssue("ABC-123");
 
     expect(hookCalls).toEqual([first.path]);
+  });
+
+  it("removes tmp and .elixir_ls artifacts during workspace preparation", async () => {
+    const root = await createRoot();
+    const manager = new WorkspaceManager({ root });
+    const existing = await manager.createForIssue("ABC-123");
+
+    await mkdir(join(existing.path, "tmp"), { recursive: true });
+    await writeFile(join(existing.path, "tmp", "cache.txt"), "cache");
+    await mkdir(join(existing.path, ".elixir_ls"), { recursive: true });
+    await writeFile(join(existing.path, ".elixir_ls", "state"), "state");
+    await writeFile(join(existing.path, "keep.txt"), "keep");
+
+    const reused = await manager.createForIssue("ABC-123");
+
+    expect(reused.createdNow).toBe(false);
+    await expect(readdir(existing.path)).resolves.toEqual(["keep.txt"]);
   });
 
   it("runs beforeRemove as a best-effort hook when deleting an existing workspace", async () => {


### PR DESCRIPTION
## Problem
Task 17 requires a conformance-oriented test matrix aligned to the spec. The current repository had baseline coverage for implemented modules, but several spec bullets still lacked direct assertions.

## Scope
- add conformance-oriented coverage for workflow path resolution, env/path expansion, Codex handshake payloads, and shell launch behavior
- add workspace prep coverage for temporary artifact cleanup
- implement workspace cleanup of `tmp` and `.elixir_ls` during workspace preparation
- apply formatter-driven cleanup in tracker files touched by lint/typecheck validation

## Test Evidence
- `pnpm exec vitest run`
- `pnpm typecheck`
- `pnpm lint`

## TODO / Not Completed In This PR
- Task 17 is not fully complete at the repository level yet
- Spec Sections 17.4, 17.6, and 17.7 still cannot be covered end-to-end because the corresponding orchestrator, observability, and CLI implementations are not present in `src/`
- After those implementations land, we still need to add the remaining conformance suites for orchestrator dispatch/retry/reconciliation, observability surfaces, and CLI/host lifecycle

## References
- `IMPLEMENTATION_PLAN.md`
- `SPEC.upstream.md`
