### PR TITLE
Add linear_graphql dynamic tool

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,8 +23,9 @@
     "vitest": "^3.0.8"
   },
   "dependencies": {
+    "graphql": "^16.13.1",
+    "liquidjs": "^10.24.0",
     "yaml": "^2.8.2",
-    "zod": "^4.3.6",
-    "liquidjs": "^10.24.0"
+    "zod": "^4.3.6"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      graphql:
+        specifier: ^16.13.1
+        version: 16.13.1
       liquidjs:
         specifier: ^10.24.0
         version: 10.24.0
@@ -489,6 +492,10 @@ packages:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
+
+  graphql@16.13.1:
+    resolution: {integrity: sha512-gGgrVCoDKlIZ8fIqXBBb0pPKqDgki0Z/FSKNiQzSGj2uEYHr1tq5wmBegGwJx6QB5S5cM0khSBpi/JFHMCvsmQ==}
+    engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
 
   js-tokens@9.0.1:
     resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
@@ -979,6 +986,8 @@ snapshots:
 
   fsevents@2.3.3:
     optional: true
+
+  graphql@16.13.1: {}
 
   js-tokens@9.0.1: {}
 

--- a/src/codex/app-server-client.ts
+++ b/src/codex/app-server-client.ts
@@ -53,6 +53,10 @@ export interface CodexDynamicToolDefinition {
   inputSchema?: Record<string, unknown>;
 }
 
+export interface CodexDynamicTool extends CodexDynamicToolDefinition {
+  execute: (input: unknown) => Promise<object>;
+}
+
 export interface CodexAppServerClientOptions {
   command: string;
   cwd: string;
@@ -68,6 +72,7 @@ export interface CodexAppServerClientOptions {
   };
   capabilities?: Record<string, unknown>;
   tools?: CodexDynamicToolDefinition[];
+  dynamicTools?: CodexDynamicTool[];
   maxLineBytes?: number;
   onEvent?: (event: CodexClientEvent) => void;
 }
@@ -303,7 +308,7 @@ export class CodexAppServerClient {
         approvalPolicy: this.options.approvalPolicy,
         sandbox: this.options.threadSandbox,
         cwd: this.options.cwd,
-        tools: this.options.tools ?? [],
+        tools: this.getAdvertisedTools(),
       });
 
       const threadId = extractNestedString(threadResult, [
@@ -498,6 +503,12 @@ export class CodexAppServerClient {
 
     if (isToolCallRequest(parsed, method)) {
       const toolName = extractToolName(parsed);
+      const tool = toolName === null ? null : this.findDynamicTool(toolName);
+      if (tool !== null && responseId !== null) {
+        void this.handleDynamicToolCall(responseId, tool, parsed);
+        return;
+      }
+
       if (responseId !== null) {
         this.send({
           id: parsed.id,
@@ -781,6 +792,59 @@ export class CodexAppServerClient {
   private get maxLineBytes(): number {
     return this.options.maxLineBytes ?? DEFAULT_MAX_LINE_BYTES;
   }
+
+  private getAdvertisedTools(): CodexDynamicToolDefinition[] {
+    const advertised = new Map<string, CodexDynamicToolDefinition>();
+
+    for (const tool of this.options.tools ?? []) {
+      advertised.set(tool.name, tool);
+    }
+
+    for (const tool of this.options.dynamicTools ?? []) {
+      advertised.set(tool.name, {
+        name: tool.name,
+        ...(tool.description === undefined
+          ? {}
+          : { description: tool.description }),
+        ...(tool.inputSchema === undefined
+          ? {}
+          : { inputSchema: tool.inputSchema }),
+      });
+    }
+
+    return [...advertised.values()];
+  }
+
+  private findDynamicTool(name: string): CodexDynamicTool | null {
+    return (
+      this.options.dynamicTools?.find((tool) => tool.name === name) ?? null
+    );
+  }
+
+  private async handleDynamicToolCall(
+    requestId: JsonRpcId,
+    tool: CodexDynamicTool,
+    message: JsonObject,
+  ): Promise<void> {
+    try {
+      const result = await tool.execute(extractToolInput(message));
+      this.send({
+        id: requestId,
+        result,
+      });
+    } catch (error) {
+      this.send({
+        id: requestId,
+        result: {
+          success: false,
+          error: {
+            code: ERROR_CODES.codexDynamicToolRejected,
+            message: `Dynamic tool ${tool.name} failed: ${toErrorMessage(error)}`,
+          },
+        },
+      });
+    }
+  }
 }
 
 function parseJsonLine(line: string): JsonObject | null {
@@ -871,6 +935,35 @@ function extractToolName(message: JsonObject): string | null {
   ];
 
   return directNames.find((value) => value !== null) ?? null;
+}
+
+function extractToolInput(message: JsonObject): unknown {
+  const params =
+    message.params !== null &&
+    typeof message.params === "object" &&
+    !Array.isArray(message.params)
+      ? (message.params as JsonObject)
+      : null;
+
+  if (params === null) {
+    return undefined;
+  }
+
+  const candidates = [
+    params.input,
+    params.arguments,
+    params.args,
+    params.payload,
+    params.toolInput,
+  ];
+
+  for (const candidate of candidates) {
+    if (candidate !== undefined) {
+      return candidate;
+    }
+  }
+
+  return undefined;
 }
 
 function extractUsage(message: JsonObject): CodexUsage | null {

--- a/src/codex/linear-graphql-tool.ts
+++ b/src/codex/linear-graphql-tool.ts
@@ -1,0 +1,258 @@
+import { type DocumentNode, parse } from "graphql";
+
+import { ERROR_CODES } from "../errors/codes.js";
+import { TrackerError } from "../tracker/errors.js";
+import {
+  LinearTrackerClient,
+  type LinearTrackerClientOptions,
+} from "../tracker/linear-client.js";
+import type { CodexDynamicTool } from "./app-server-client.js";
+
+const LINEAR_GRAPHQL_DESCRIPTION =
+  "Execute one GraphQL query or mutation against the configured Linear workspace using Symphony-managed auth.";
+
+type JsonObject = Record<string, unknown>;
+
+export interface LinearGraphqlToolInput {
+  query: string;
+  variables?: JsonObject;
+}
+
+export interface LinearGraphqlToolResult {
+  success: boolean;
+  response?: {
+    status?: number;
+    body?: unknown;
+  };
+  error?: {
+    code: string;
+    message: string;
+    details?: unknown;
+    status?: number | null;
+  };
+}
+
+export interface LinearGraphqlDynamicToolOptions
+  extends Pick<
+    LinearTrackerClientOptions,
+    "endpoint" | "apiKey" | "networkTimeoutMs" | "fetchFn"
+  > {}
+
+export const LINEAR_GRAPHQL_TOOL_NAME = "linear_graphql";
+
+export function createLinearGraphqlDynamicTool(
+  options: LinearGraphqlDynamicToolOptions,
+): CodexDynamicTool {
+  const client = new LinearTrackerClient({
+    endpoint: options.endpoint,
+    apiKey: options.apiKey,
+    projectSlug: null,
+    activeStates: [],
+    ...(options.networkTimeoutMs === undefined
+      ? {}
+      : { networkTimeoutMs: options.networkTimeoutMs }),
+    ...(options.fetchFn === undefined ? {} : { fetchFn: options.fetchFn }),
+  });
+
+  return {
+    name: LINEAR_GRAPHQL_TOOL_NAME,
+    description: LINEAR_GRAPHQL_DESCRIPTION,
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["query"],
+      properties: {
+        query: {
+          type: "string",
+          minLength: 1,
+          description: "A single GraphQL query or mutation document.",
+        },
+        variables: {
+          type: "object",
+          description: "Optional GraphQL variables object.",
+        },
+      },
+    },
+    async execute(input: unknown): Promise<LinearGraphqlToolResult> {
+      const normalized = normalizeInput(input);
+      if (!normalized.success) {
+        return normalized;
+      }
+
+      try {
+        const response = await client.executeRawGraphql(
+          normalized.query,
+          normalized.variables,
+        );
+        const body = response.body;
+        const graphqlErrors = extractGraphqlErrors(body);
+
+        if (response.status < 200 || response.status >= 300) {
+          return {
+            success: false,
+            response: {
+              status: response.status,
+              body,
+            },
+            error: {
+              code: ERROR_CODES.linearApiStatus,
+              message: `Linear GraphQL request failed with HTTP ${response.status}.`,
+              status: response.status,
+            },
+          };
+        }
+
+        if (graphqlErrors !== null) {
+          return {
+            success: false,
+            response: {
+              status: response.status,
+              body,
+            },
+            error: {
+              code: ERROR_CODES.linearGraphqlErrors,
+              message: "Linear GraphQL returned top-level errors.",
+              details: graphqlErrors,
+              status: response.status,
+            },
+          };
+        }
+
+        return {
+          success: true,
+          response: {
+            status: response.status,
+            body,
+          },
+        };
+      } catch (error) {
+        if (error instanceof TrackerError) {
+          return {
+            success: false,
+            error: {
+              code: error.code,
+              message: error.message,
+              details: error.details,
+              status: error.status,
+            },
+          };
+        }
+
+        return {
+          success: false,
+          error: {
+            code: ERROR_CODES.linearApiRequest,
+            message:
+              error instanceof Error
+                ? error.message
+                : "Linear GraphQL request failed.",
+          },
+        };
+      }
+    },
+  };
+}
+
+function normalizeInput(
+  input: unknown,
+):
+  | (LinearGraphqlToolResult & { success: false })
+  | { success: true; query: string; variables: JsonObject } {
+  if (typeof input === "string") {
+    return validateDocument({
+      query: input,
+      variables: {},
+    });
+  }
+
+  if (input === null || typeof input !== "object" || Array.isArray(input)) {
+    return invalidInput(
+      "linear_graphql expects a GraphQL string or an object with query and optional variables.",
+    );
+  }
+
+  const query = "query" in input ? input.query : undefined;
+  if (typeof query !== "string" || query.trim().length === 0) {
+    return invalidInput("linear_graphql.query must be a non-empty string.");
+  }
+
+  const variablesValue = "variables" in input ? input.variables : undefined;
+  if (variablesValue === undefined) {
+    return validateDocument({
+      query,
+      variables: {},
+    });
+  }
+
+  if (
+    variablesValue === null ||
+    typeof variablesValue !== "object" ||
+    Array.isArray(variablesValue)
+  ) {
+    return invalidInput("linear_graphql.variables must be a JSON object.");
+  }
+
+  return validateDocument({
+    query,
+    variables: variablesValue as JsonObject,
+  });
+}
+
+function validateDocument(input: {
+  query: string;
+  variables: JsonObject;
+}):
+  | (LinearGraphqlToolResult & { success: false })
+  | { success: true; query: string; variables: JsonObject } {
+  let document: DocumentNode;
+
+  try {
+    document = parse(input.query);
+  } catch (error) {
+    return invalidInput(
+      error instanceof Error
+        ? `linear_graphql.query is not valid GraphQL: ${error.message}`
+        : "linear_graphql.query is not valid GraphQL.",
+    );
+  }
+
+  const operationCount = document.definitions.filter(
+    (definition) => definition.kind === "OperationDefinition",
+  ).length;
+
+  if (operationCount !== 1) {
+    return invalidInput(
+      "linear_graphql.query must contain exactly one GraphQL operation.",
+      { operationCount },
+    );
+  }
+
+  return {
+    success: true,
+    query: input.query,
+    variables: input.variables,
+  };
+}
+
+function extractGraphqlErrors(body: unknown): unknown[] | null {
+  if (body === null || typeof body !== "object" || Array.isArray(body)) {
+    return null;
+  }
+
+  const errors = (body as JsonObject).errors;
+  return Array.isArray(errors) && errors.length > 0 ? errors : null;
+}
+
+function invalidInput(
+  message: string,
+  details?: unknown,
+): LinearGraphqlToolResult & { success: false } {
+  return {
+    success: false,
+    error: {
+      code: "invalid_input",
+      message,
+      details: details ?? null,
+    },
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ export * from "./config/defaults.js";
 export * from "./config/config-resolver.js";
 export * from "./config/types.js";
 export * from "./codex/app-server-client.js";
+export * from "./codex/linear-graphql-tool.js";
 export * from "./config/workflow-loader.js";
 export * from "./config/workflow-watch.js";
 export * from "./domain/model.js";

--- a/src/tracker/linear-client.ts
+++ b/src/tracker/linear-client.ts
@@ -31,6 +31,11 @@ interface LinearGraphqlResponse<TData> {
   errors?: unknown;
 }
 
+export interface LinearRawGraphqlResponse {
+  status: number;
+  body: unknown;
+}
+
 interface LinearCandidateData {
   issues?: LinearGraphqlConnection<unknown>;
 }
@@ -117,6 +122,20 @@ export class LinearTrackerClient implements IssueTracker {
     }
 
     return nodes.map((node) => normalizeLinearIssueState(node));
+  }
+
+  async executeRawGraphql(
+    query: string,
+    variables: Record<string, unknown> = {},
+  ): Promise<LinearRawGraphqlResponse> {
+    const apiKey = this.requireApiKey();
+    const response = await this.fetchWithTimeout(query, variables, apiKey);
+    const body = await parseGraphqlResponseBody(response);
+
+    return {
+      status: response.status,
+      body,
+    };
   }
 
   private async fetchIssuePages(
@@ -273,5 +292,20 @@ export class LinearTrackerClient implements IssueTracker {
     }
 
     return this.projectSlug;
+  }
+}
+
+async function parseGraphqlResponseBody(response: Response): Promise<unknown> {
+  const text = await response.text();
+  if (text.trim().length === 0) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    return {
+      raw: text,
+    };
   }
 }

--- a/tests/codex/app-server-client.test.ts
+++ b/tests/codex/app-server-client.test.ts
@@ -3,13 +3,14 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   CodexAppServerClient,
   type CodexAppServerClientError,
   type CodexClientEvent,
 } from "../../src/codex/app-server-client.js";
+import { createLinearGraphqlDynamicTool } from "../../src/codex/linear-graphql-tool.js";
 import { ERROR_CODES } from "../../src/errors/codes.js";
 
 const roots: string[] = [];
@@ -135,6 +136,43 @@ describe("CodexAppServerClient", () => {
     await client.close();
   });
 
+  it("advertises and executes the linear_graphql dynamic tool", async () => {
+    const workspace = await createWorkspace();
+    const events: CodexClientEvent[] = [];
+    const fetchFn = vi.fn<typeof fetch>().mockResolvedValue(
+      jsonResponse({
+        data: {
+          viewer: {
+            id: "viewer-1",
+            name: "Example User",
+          },
+        },
+      }),
+    );
+    const client = createClient("linear-tool", workspace, events, {
+      dynamicTools: [
+        createLinearGraphqlDynamicTool({
+          endpoint: "https://api.linear.app/graphql",
+          apiKey: "linear-token",
+          fetchFn,
+        }),
+      ],
+    });
+
+    const result = await client.startSession({
+      prompt: "Use the tracker tool",
+      title: "ABC-123: Example",
+    });
+
+    expect(result.status).toBe("completed");
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+    expect(events.map((event) => event.event)).not.toContain(
+      "unsupported_tool_call",
+    );
+
+    await client.close();
+  });
+
   it("enforces read timeouts during the startup handshake", async () => {
     const workspace = await createWorkspace();
     const events: CodexClientEvent[] = [];
@@ -196,6 +234,9 @@ function createClient(
     readTimeoutMs: number;
     turnTimeoutMs: number;
     stallTimeoutMs: number;
+    dynamicTools: NonNullable<
+      ConstructorParameters<typeof CodexAppServerClient>[0]["dynamicTools"]
+    >;
   }>,
 ): CodexAppServerClient {
   return new CodexAppServerClient({
@@ -209,8 +250,20 @@ function createClient(
     readTimeoutMs: overrides?.readTimeoutMs ?? 750,
     turnTimeoutMs: overrides?.turnTimeoutMs ?? 500,
     stallTimeoutMs: overrides?.stallTimeoutMs ?? 1_000,
+    ...(overrides?.dynamicTools === undefined
+      ? {}
+      : { dynamicTools: overrides.dynamicTools }),
     onEvent: (event) => {
       events.push(event);
+    },
+  });
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      "content-type": "application/json",
     },
   });
 }

--- a/tests/codex/linear-graphql-tool.test.ts
+++ b/tests/codex/linear-graphql-tool.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  ERROR_CODES,
+  createLinearGraphqlDynamicTool,
+} from "../../src/index.js";
+
+describe("createLinearGraphqlDynamicTool", () => {
+  it("accepts raw GraphQL string shorthand and returns a successful response", async () => {
+    const fetchFn = vi.fn<typeof fetch>().mockResolvedValue(
+      jsonResponse({
+        data: {
+          viewer: {
+            id: "viewer-1",
+          },
+        },
+      }),
+    );
+    const tool = createLinearGraphqlDynamicTool({
+      endpoint: "https://api.linear.app/graphql",
+      apiKey: "linear-token",
+      fetchFn,
+    });
+
+    await expect(
+      tool.execute("query Viewer { viewer { id } }"),
+    ).resolves.toEqual({
+      success: true,
+      response: {
+        status: 200,
+        body: {
+          data: {
+            viewer: {
+              id: "viewer-1",
+            },
+          },
+        },
+      },
+    });
+  });
+
+  it("rejects multiple GraphQL operations as invalid input", async () => {
+    const tool = createLinearGraphqlDynamicTool({
+      endpoint: "https://api.linear.app/graphql",
+      apiKey: "linear-token",
+      fetchFn: vi.fn<typeof fetch>(),
+    });
+
+    await expect(
+      tool.execute({
+        query:
+          "query Viewer { viewer { id } } query Teams { teams { nodes { id } } }",
+      }),
+    ).resolves.toMatchObject({
+      success: false,
+      error: {
+        code: "invalid_input",
+      },
+    });
+  });
+
+  it("rejects non-object variables", async () => {
+    const tool = createLinearGraphqlDynamicTool({
+      endpoint: "https://api.linear.app/graphql",
+      apiKey: "linear-token",
+      fetchFn: vi.fn<typeof fetch>(),
+    });
+
+    await expect(
+      tool.execute({
+        query: "query Viewer { viewer { id } }",
+        variables: ["bad"],
+      }),
+    ).resolves.toMatchObject({
+      success: false,
+      error: {
+        code: "invalid_input",
+        message: "linear_graphql.variables must be a JSON object.",
+      },
+    });
+  });
+
+  it("preserves top-level GraphQL errors with success=false", async () => {
+    const fetchFn = vi.fn<typeof fetch>().mockResolvedValue(
+      jsonResponse({
+        data: null,
+        errors: [{ message: "forbidden" }],
+      }),
+    );
+    const tool = createLinearGraphqlDynamicTool({
+      endpoint: "https://api.linear.app/graphql",
+      apiKey: "linear-token",
+      fetchFn,
+    });
+
+    await expect(
+      tool.execute({
+        query: 'mutation UpdateIssue { issueUpdate(id: "1") { success } }',
+      }),
+    ).resolves.toEqual({
+      success: false,
+      response: {
+        status: 200,
+        body: {
+          data: null,
+          errors: [{ message: "forbidden" }],
+        },
+      },
+      error: {
+        code: ERROR_CODES.linearGraphqlErrors,
+        message: "Linear GraphQL returned top-level errors.",
+        details: [{ message: "forbidden" }],
+        status: 200,
+      },
+    });
+  });
+
+  it("returns structured failures for missing auth and transport errors", async () => {
+    const missingAuthTool = createLinearGraphqlDynamicTool({
+      endpoint: "https://api.linear.app/graphql",
+      apiKey: null,
+      fetchFn: vi.fn<typeof fetch>(),
+    });
+    const transportTool = createLinearGraphqlDynamicTool({
+      endpoint: "https://api.linear.app/graphql",
+      apiKey: "linear-token",
+      fetchFn: vi
+        .fn<typeof fetch>()
+        .mockRejectedValue(new Error("network down")),
+    });
+
+    await expect(
+      missingAuthTool.execute({
+        query: "query Viewer { viewer { id } }",
+      }),
+    ).resolves.toMatchObject({
+      success: false,
+      error: {
+        code: ERROR_CODES.missingTrackerApiKey,
+      },
+    });
+
+    await expect(
+      transportTool.execute({
+        query: "query Viewer { viewer { id } }",
+      }),
+    ).resolves.toMatchObject({
+      success: false,
+      error: {
+        code: ERROR_CODES.linearApiRequest,
+      },
+    });
+  });
+});
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      "content-type": "application/json",
+    },
+  });
+}

--- a/tests/fixtures/codex-fake-server.mjs
+++ b/tests/fixtures/codex-fake-server.mjs
@@ -50,6 +50,13 @@ async function handleMessage(message) {
       realpathSync(message.params.cwd),
       "spawn cwd must equal request cwd",
     );
+    if (scenario === "linear-tool") {
+      assertEqual(
+        message.params.tools?.[0]?.name,
+        "linear_graphql",
+        "thread/start must advertise linear_graphql",
+      );
+    }
     writeJson({
       id: message.id,
       result: {
@@ -162,7 +169,17 @@ async function handleMessage(message) {
         id: "tool-1",
         method: "item/tool/call",
         params: {
-          toolName: "not_supported",
+          toolName:
+            scenario === "linear-tool" ? "linear_graphql" : "not_supported",
+          input:
+            scenario === "linear-tool"
+              ? {
+                  query: "query Viewer { viewer { id name } }",
+                  variables: {
+                    includeArchived: false,
+                  },
+                }
+              : undefined,
         },
       });
     }, 10);
@@ -170,11 +187,24 @@ async function handleMessage(message) {
   }
 
   if (message.id === "tool-1") {
-    assertEqual(
-      message.result?.success,
-      false,
-      "unsupported tool calls must return success=false",
-    );
+    if (scenario === "linear-tool") {
+      assertEqual(
+        message.result?.success,
+        true,
+        "supported linear_graphql tool call must succeed",
+      );
+      assertEqual(
+        message.result?.response?.body?.data?.viewer?.id,
+        "viewer-1",
+        "linear_graphql tool must return the GraphQL response body",
+      );
+    } else {
+      assertEqual(
+        message.result?.success,
+        false,
+        "unsupported tool calls must return success=false",
+      );
+    }
 
     setTimeout(() => {
       writeJson({


### PR DESCRIPTION
## Summary
- implement Task 10 from `IMPLEMENTATION_PLAN.md`: the optional `linear_graphql` dynamic tool
- advertise the tool through the Codex app-server client and execute supported tool calls in-session
- validate tool input so each call contains exactly one GraphQL operation and returns structured success or failure payloads
- extend the Linear client and Codex fixtures/tests to cover supported tool execution and failure cases

## Scope
This PR covers Task 10: `linear_graphql` dynamic tool.

## Testing
- `pnpm typecheck`
- `pnpm test`
- `pnpm lint`