### PR TITLE
Add orchestrator core

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ export * from "./logging/fields.js";
 export * from "./logging/runtime-snapshot.js";
 export * from "./logging/session-metrics.js";
 export * from "./logging/structured-logger.js";
+export * from "./orchestrator/core.js";
 export * from "./workspace/hooks.js";
 export * from "./tracker/errors.js";
 export * from "./tracker/linear-client.js";

--- a/src/orchestrator/core.ts
+++ b/src/orchestrator/core.ts
@@ -1,0 +1,648 @@
+import {
+  createEmptyLiveSession,
+  createInitialOrchestratorState,
+  normalizeIssueState,
+  type Issue,
+  type OrchestratorState,
+  type RetryEntry,
+  type RunningEntry,
+} from "../domain/model.js";
+import { addEndedSessionRuntime } from "../logging/session-metrics.js";
+import { validateDispatchConfig } from "../config/config-resolver.js";
+import type {
+  DispatchValidationResult,
+  ResolvedWorkflowConfig,
+} from "../config/types.js";
+import type { IssueStateSnapshot, IssueTracker } from "../tracker/tracker.js";
+
+const CONTINUATION_RETRY_DELAY_MS = 1_000;
+const FAILURE_RETRY_BASE_DELAY_MS = 10_000;
+
+export type WorkerExitOutcome = "normal" | "abnormal";
+
+export type StopReason =
+  | "terminal_state"
+  | "inactive_state"
+  | "stall_timeout";
+
+export interface SpawnWorkerResult {
+  workerHandle: unknown;
+  monitorHandle: unknown;
+}
+
+export interface StopRequest {
+  issueId: string;
+  issueIdentifier: string;
+  cleanupWorkspace: boolean;
+  reason: StopReason;
+}
+
+export interface PollTickResult {
+  validation: DispatchValidationResult;
+  dispatchedIssueIds: string[];
+  stopRequests: StopRequest[];
+  trackerFetchFailed: boolean;
+  reconciliationFetchFailed: boolean;
+}
+
+export interface RetryTimerResult {
+  dispatched: boolean;
+  released: boolean;
+  retryEntry: RetryEntry | null;
+}
+
+export interface TimerScheduler {
+  set(
+    callback: () => void,
+    delayMs: number,
+  ): ReturnType<typeof setTimeout> | null;
+  clear(handle: ReturnType<typeof setTimeout> | null): void;
+}
+
+export interface OrchestratorCoreOptions {
+  config: ResolvedWorkflowConfig;
+  tracker: IssueTracker;
+  spawnWorker: (input: {
+    issue: Issue;
+    attempt: number | null;
+  }) => Promise<SpawnWorkerResult> | SpawnWorkerResult;
+  stopRunningIssue?: (input: {
+    issueId: string;
+    runningEntry: RunningEntry;
+    cleanupWorkspace: boolean;
+    reason: StopReason;
+  }) => Promise<void> | void;
+  timerScheduler?: TimerScheduler;
+  now?: () => Date;
+}
+
+export class OrchestratorCore {
+  private config: ResolvedWorkflowConfig;
+
+  private readonly tracker: IssueTracker;
+
+  private readonly spawnWorker: OrchestratorCoreOptions["spawnWorker"];
+
+  private readonly stopRunningIssue?: OrchestratorCoreOptions["stopRunningIssue"];
+
+  private readonly timerScheduler: TimerScheduler;
+
+  private readonly now: () => Date;
+
+  private readonly state: OrchestratorState;
+
+  constructor(options: OrchestratorCoreOptions) {
+    this.config = options.config;
+    this.tracker = options.tracker;
+    this.spawnWorker = options.spawnWorker;
+    this.stopRunningIssue = options.stopRunningIssue;
+    this.timerScheduler = options.timerScheduler ?? defaultTimerScheduler();
+    this.now = options.now ?? (() => new Date());
+    this.state = createInitialOrchestratorState({
+      pollIntervalMs: options.config.polling.intervalMs,
+      maxConcurrentAgents: options.config.agent.maxConcurrentAgents,
+    });
+  }
+
+  getState(): OrchestratorState {
+    return this.state;
+  }
+
+  updateConfig(config: ResolvedWorkflowConfig): void {
+    this.config = config;
+    this.syncStateFromConfig();
+  }
+
+  isDispatchEligible(
+    issue: Issue,
+    options?: {
+      allowClaimedIssueId?: string;
+    },
+  ): boolean {
+    if (
+      issue.id.trim() === "" ||
+      issue.identifier.trim() === "" ||
+      issue.title.trim() === "" ||
+      issue.state.trim() === ""
+    ) {
+      return false;
+    }
+
+    const normalizedState = normalizeIssueState(issue.state);
+    const activeStates = toNormalizedStateSet(this.config.tracker.activeStates);
+    const terminalStates = toNormalizedStateSet(
+      this.config.tracker.terminalStates,
+    );
+    if (
+      !activeStates.has(normalizedState) ||
+      terminalStates.has(normalizedState) ||
+      this.state.running[issue.id] !== undefined
+    ) {
+      return false;
+    }
+
+    const allowClaimedIssueId = options?.allowClaimedIssueId;
+    if (
+      this.state.claimed.has(issue.id) &&
+      (allowClaimedIssueId === undefined || allowClaimedIssueId !== issue.id)
+    ) {
+      return false;
+    }
+
+    if (this.availableSlots() <= 0 || this.availableSlotsForState(issue.state) <= 0) {
+      return false;
+    }
+
+    if (normalizedState !== "todo") {
+      return true;
+    }
+
+    return issue.blockedBy.every((blocker) => {
+      const blockerState = blocker.state === null ? null : normalizeIssueState(blocker.state);
+      return blockerState !== null && terminalStates.has(blockerState);
+    });
+  }
+
+  async pollTick(): Promise<PollTickResult> {
+    this.syncStateFromConfig();
+
+    const reconcileResult = await this.reconcileRunningIssues();
+    const validation = validateDispatchConfig(this.config);
+    if (!validation.ok) {
+      return {
+        validation,
+        dispatchedIssueIds: [],
+        stopRequests: reconcileResult.stopRequests,
+        trackerFetchFailed: false,
+        reconciliationFetchFailed: reconcileResult.reconciliationFetchFailed,
+      };
+    }
+
+    let issues: Issue[];
+    try {
+      issues = await this.tracker.fetchCandidateIssues();
+    } catch {
+      return {
+        validation,
+        dispatchedIssueIds: [],
+        stopRequests: reconcileResult.stopRequests,
+        trackerFetchFailed: true,
+        reconciliationFetchFailed: reconcileResult.reconciliationFetchFailed,
+      };
+    }
+
+    const dispatchedIssueIds: string[] = [];
+    for (const issue of sortIssuesForDispatch(issues)) {
+      if (this.availableSlots() <= 0) {
+        break;
+      }
+
+      if (!this.isDispatchEligible(issue)) {
+        continue;
+      }
+
+      const dispatched = await this.dispatchIssue(issue, null);
+      if (dispatched) {
+        dispatchedIssueIds.push(issue.id);
+      }
+    }
+
+    return {
+      validation,
+      dispatchedIssueIds,
+      stopRequests: reconcileResult.stopRequests,
+      trackerFetchFailed: false,
+      reconciliationFetchFailed: reconcileResult.reconciliationFetchFailed,
+    };
+  }
+
+  async onRetryTimer(issueId: string): Promise<RetryTimerResult> {
+    const retryEntry = this.state.retryAttempts[issueId];
+    if (retryEntry === undefined) {
+      return {
+        dispatched: false,
+        released: false,
+        retryEntry: null,
+      };
+    }
+
+    this.clearRetryEntry(issueId);
+
+    let candidates: Issue[];
+    try {
+      candidates = await this.tracker.fetchCandidateIssues();
+    } catch {
+      return {
+        dispatched: false,
+        released: false,
+        retryEntry: this.scheduleRetry(issueId, retryEntry.attempt + 1, {
+          identifier: retryEntry.identifier,
+          error: "retry poll failed",
+          delayType: "failure",
+        }),
+      };
+    }
+
+    const issue = candidates.find((candidate) => candidate.id === issueId) ?? null;
+    if (issue === null) {
+      this.releaseClaim(issueId);
+      return {
+        dispatched: false,
+        released: true,
+        retryEntry: null,
+      };
+    }
+
+    if (!this.isRetryCandidateEligible(issue)) {
+      this.releaseClaim(issueId);
+      return {
+        dispatched: false,
+        released: true,
+        retryEntry: null,
+      };
+    }
+
+    if (this.availableSlots() <= 0 || this.availableSlotsForState(issue.state) <= 0) {
+      return {
+        dispatched: false,
+        released: false,
+        retryEntry: this.scheduleRetry(issueId, retryEntry.attempt + 1, {
+          identifier: issue.identifier,
+          error: "no available orchestrator slots",
+          delayType: "failure",
+        }),
+      };
+    }
+
+    const dispatched = await this.dispatchIssue(issue, retryEntry.attempt);
+    return {
+      dispatched,
+      released: false,
+      retryEntry: null,
+    };
+  }
+
+  onWorkerExit(input: {
+    issueId: string;
+    outcome: WorkerExitOutcome;
+    reason?: string;
+    endedAt?: Date;
+  }): RetryEntry | null {
+    const runningEntry = this.state.running[input.issueId];
+    if (runningEntry === undefined) {
+      return null;
+    }
+
+    delete this.state.running[input.issueId];
+    addEndedSessionRuntime(this.state, runningEntry.startedAt, input.endedAt ?? this.now());
+
+    if (input.outcome === "normal") {
+      this.state.completed.add(input.issueId);
+      return this.scheduleRetry(input.issueId, 1, {
+        identifier: runningEntry.identifier,
+        error: null,
+        delayType: "continuation",
+      });
+    }
+
+    return this.scheduleRetry(
+      input.issueId,
+      nextRetryAttempt(runningEntry.retryAttempt),
+      {
+        identifier: runningEntry.identifier,
+        error: formatWorkerExitReason(input.reason),
+        delayType: "failure",
+      },
+    );
+  }
+
+  private syncStateFromConfig(): void {
+    this.state.pollIntervalMs = this.config.polling.intervalMs;
+    this.state.maxConcurrentAgents = this.config.agent.maxConcurrentAgents;
+  }
+
+  private availableSlots(): number {
+    return Math.max(
+      this.state.maxConcurrentAgents - Object.keys(this.state.running).length,
+      0,
+    );
+  }
+
+  private availableSlotsForState(issueState: string): number {
+    const normalizedState = normalizeIssueState(issueState);
+    const limit =
+      this.config.agent.maxConcurrentAgentsByState[normalizedState] ??
+      this.state.maxConcurrentAgents;
+    const runningForState = Object.values(this.state.running).filter(
+      (entry) => normalizeIssueState(entry.issue.state) === normalizedState,
+    ).length;
+    return Math.max(limit - runningForState, 0);
+  }
+
+  private isRetryCandidateEligible(issue: Issue): boolean {
+    if (
+      issue.id.trim() === "" ||
+      issue.identifier.trim() === "" ||
+      issue.title.trim() === "" ||
+      issue.state.trim() === ""
+    ) {
+      return false;
+    }
+
+    const normalizedState = normalizeIssueState(issue.state);
+    const activeStates = toNormalizedStateSet(this.config.tracker.activeStates);
+    const terminalStates = toNormalizedStateSet(
+      this.config.tracker.terminalStates,
+    );
+    if (
+      !activeStates.has(normalizedState) ||
+      terminalStates.has(normalizedState) ||
+      this.state.running[issue.id] !== undefined
+    ) {
+      return false;
+    }
+
+    if (normalizedState !== "todo") {
+      return true;
+    }
+
+    return issue.blockedBy.every((blocker) => {
+      const blockerState =
+        blocker.state === null ? null : normalizeIssueState(blocker.state);
+      return blockerState !== null && terminalStates.has(blockerState);
+    });
+  }
+
+  private async dispatchIssue(
+    issue: Issue,
+    attempt: number | null,
+  ): Promise<boolean> {
+    try {
+      const spawned = await this.spawnWorker({ issue, attempt });
+      this.state.running[issue.id] = {
+        ...createEmptyLiveSession(),
+        issue,
+        identifier: issue.identifier,
+        retryAttempt: normalizeRetryAttempt(attempt),
+        startedAt: this.now().toISOString(),
+        workerHandle: spawned.workerHandle,
+        monitorHandle: spawned.monitorHandle,
+      };
+      this.state.claimed.add(issue.id);
+      this.clearRetryEntry(issue.id);
+      return true;
+    } catch {
+      this.scheduleRetry(issue.id, nextRetryAttempt(attempt), {
+        identifier: issue.identifier,
+        error: "failed to spawn agent",
+        delayType: "failure",
+      });
+      return false;
+    }
+  }
+
+  private async reconcileRunningIssues(): Promise<{
+    stopRequests: StopRequest[];
+    reconciliationFetchFailed: boolean;
+  }> {
+    const stopRequests = await this.reconcileStalledRuns();
+    const runningIds = Object.keys(this.state.running);
+    if (runningIds.length === 0) {
+      return {
+        stopRequests,
+        reconciliationFetchFailed: false,
+      };
+    }
+
+    let refreshed: IssueStateSnapshot[];
+    try {
+      refreshed = await this.tracker.fetchIssueStatesByIds(runningIds);
+    } catch {
+      return {
+        stopRequests,
+        reconciliationFetchFailed: true,
+      };
+    }
+
+    const activeStates = toNormalizedStateSet(this.config.tracker.activeStates);
+    const terminalStates = toNormalizedStateSet(this.config.tracker.terminalStates);
+
+    for (const snapshot of refreshed) {
+      const runningEntry = this.state.running[snapshot.id];
+      if (runningEntry === undefined) {
+        continue;
+      }
+
+      const normalizedState = normalizeIssueState(snapshot.state);
+      if (terminalStates.has(normalizedState)) {
+        stopRequests.push(
+          await this.requestStop(runningEntry, true, "terminal_state"),
+        );
+        continue;
+      }
+
+      if (activeStates.has(normalizedState)) {
+        runningEntry.issue = {
+          ...runningEntry.issue,
+          identifier: snapshot.identifier,
+          state: snapshot.state,
+        };
+        runningEntry.identifier = snapshot.identifier;
+        continue;
+      }
+
+      stopRequests.push(
+        await this.requestStop(runningEntry, false, "inactive_state"),
+      );
+    }
+
+    return {
+      stopRequests,
+      reconciliationFetchFailed: false,
+    };
+  }
+
+  private async reconcileStalledRuns(): Promise<StopRequest[]> {
+    if (this.config.codex.stallTimeoutMs <= 0) {
+      return [];
+    }
+
+    const nowMs = this.now().getTime();
+    const stopRequests: StopRequest[] = [];
+    for (const runningEntry of Object.values(this.state.running)) {
+      const baselineTimestamp = parseEventTimestamp(
+        runningEntry.lastCodexTimestamp,
+        runningEntry.startedAt,
+      );
+      if (baselineTimestamp === null) {
+        continue;
+      }
+
+      if (nowMs - baselineTimestamp > this.config.codex.stallTimeoutMs) {
+        stopRequests.push(
+          await this.requestStop(runningEntry, false, "stall_timeout"),
+        );
+      }
+    }
+
+    return stopRequests;
+  }
+
+  private async requestStop(
+    runningEntry: RunningEntry,
+    cleanupWorkspace: boolean,
+    reason: StopReason,
+  ): Promise<StopRequest> {
+    const stopRequest: StopRequest = {
+      issueId: runningEntry.issue.id,
+      issueIdentifier: runningEntry.identifier,
+      cleanupWorkspace,
+      reason,
+    };
+
+    await this.stopRunningIssue?.({
+      issueId: runningEntry.issue.id,
+      runningEntry,
+      cleanupWorkspace,
+      reason,
+    });
+
+    return stopRequest;
+  }
+
+  private scheduleRetry(
+    issueId: string,
+    attempt: number,
+    input: {
+      identifier: string | null;
+      error: string | null;
+      delayType: "continuation" | "failure";
+    },
+  ): RetryEntry {
+    this.clearRetryEntry(issueId);
+
+    const delayMs =
+      input.delayType === "continuation"
+        ? CONTINUATION_RETRY_DELAY_MS
+        : computeFailureRetryDelayMs(
+            attempt,
+            this.config.agent.maxRetryBackoffMs,
+          );
+    const dueAtMs = this.now().getTime() + delayMs;
+    const timerHandle = this.timerScheduler.set(() => {
+      void this.onRetryTimer(issueId);
+    }, delayMs);
+
+    const retryEntry: RetryEntry = {
+      issueId,
+      identifier: input.identifier,
+      attempt,
+      dueAtMs,
+      timerHandle,
+      error: input.error,
+    };
+
+    this.state.claimed.add(issueId);
+    this.state.retryAttempts[issueId] = retryEntry;
+    return retryEntry;
+  }
+
+  private clearRetryEntry(issueId: string): void {
+    const current = this.state.retryAttempts[issueId];
+    if (current !== undefined) {
+      this.timerScheduler.clear(current.timerHandle);
+      delete this.state.retryAttempts[issueId];
+    }
+  }
+
+  private releaseClaim(issueId: string): void {
+    this.clearRetryEntry(issueId);
+    this.state.claimed.delete(issueId);
+  }
+}
+
+export function sortIssuesForDispatch(issues: readonly Issue[]): Issue[] {
+  return issues.slice().sort((left, right) => {
+    const priorityDelta = toSortablePriority(left.priority) - toSortablePriority(right.priority);
+    if (priorityDelta !== 0) {
+      return priorityDelta;
+    }
+
+    const createdAtDelta = toSortableDate(left.createdAt) - toSortableDate(right.createdAt);
+    if (createdAtDelta !== 0) {
+      return createdAtDelta;
+    }
+
+    return left.identifier.localeCompare(right.identifier, "en");
+  });
+}
+
+export function computeFailureRetryDelayMs(
+  attempt: number,
+  maxRetryBackoffMs: number,
+): number {
+  const normalizedAttempt = Math.max(attempt, 1);
+  const exponentialDelay =
+    FAILURE_RETRY_BASE_DELAY_MS * 2 ** (normalizedAttempt - 1);
+  return Math.min(exponentialDelay, maxRetryBackoffMs);
+}
+
+export function nextRetryAttempt(attempt: number | null): number {
+  return attempt === null ? 1 : attempt + 1;
+}
+
+function normalizeRetryAttempt(attempt: number | null): number | null {
+  return attempt === null ? null : Math.max(1, Math.floor(attempt));
+}
+
+function formatWorkerExitReason(reason: string | undefined): string {
+  const normalized = reason?.trim();
+  return normalized && normalized.length > 0
+    ? `worker exited: ${normalized}`
+    : "worker exited: abnormal";
+}
+
+function toSortablePriority(priority: number | null): number {
+  return priority === null ? Number.POSITIVE_INFINITY : priority;
+}
+
+function toSortableDate(timestamp: string | null): number {
+  if (timestamp === null) {
+    return Number.POSITIVE_INFINITY;
+  }
+
+  const parsed = Date.parse(timestamp);
+  return Number.isFinite(parsed) ? parsed : Number.POSITIVE_INFINITY;
+}
+
+function parseEventTimestamp(
+  lastCodexTimestamp: string | null,
+  startedAt: string,
+): number | null {
+  if (lastCodexTimestamp !== null) {
+    const parsed = Date.parse(lastCodexTimestamp);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+
+  const startedAtMs = Date.parse(startedAt);
+  return Number.isFinite(startedAtMs) ? startedAtMs : null;
+}
+
+function toNormalizedStateSet(states: readonly string[]): Set<string> {
+  return new Set(states.map((state) => normalizeIssueState(state)));
+}
+
+function defaultTimerScheduler(): TimerScheduler {
+  return {
+    set(callback, delayMs) {
+      return setTimeout(callback, delayMs);
+    },
+    clear(handle) {
+      if (handle !== null) {
+        clearTimeout(handle);
+      }
+    },
+  };
+}

--- a/tests/orchestrator/core.test.ts
+++ b/tests/orchestrator/core.test.ts
@@ -1,0 +1,408 @@
+import { describe, expect, it } from "vitest";
+
+import type { Issue } from "../../src/domain/model.js";
+import {
+  OrchestratorCore,
+  computeFailureRetryDelayMs,
+  sortIssuesForDispatch,
+  type OrchestratorCoreOptions,
+} from "../../src/orchestrator/core.js";
+import type { ResolvedWorkflowConfig } from "../../src/config/types.js";
+import type { IssueStateSnapshot, IssueTracker } from "../../src/tracker/tracker.js";
+
+describe("orchestrator core", () => {
+  it("sorts dispatch candidates by priority, age, and identifier", () => {
+    const issues = sortIssuesForDispatch([
+      createIssue({
+        id: "3",
+        identifier: "ISSUE-3",
+        priority: 2,
+        createdAt: "2026-03-05T00:00:00.000Z",
+      }),
+      createIssue({
+        id: "2",
+        identifier: "ISSUE-2",
+        priority: 1,
+        createdAt: "2026-03-04T00:00:00.000Z",
+      }),
+      createIssue({
+        id: "1",
+        identifier: "ISSUE-1",
+        priority: 1,
+        createdAt: "2026-03-03T00:00:00.000Z",
+      }),
+    ]);
+
+    expect(issues.map((issue) => issue.id)).toEqual(["1", "2", "3"]);
+  });
+
+  it("rejects Todo issues with non-terminal blockers and allows terminal blockers", () => {
+    const orchestrator = createOrchestrator();
+
+    expect(
+      orchestrator.isDispatchEligible(
+        createIssue({
+          id: "todo-1",
+          identifier: "ISSUE-1",
+          state: "Todo",
+          blockedBy: [{ id: "b1", identifier: "B-1", state: "In Progress" }],
+        }),
+      ),
+    ).toBe(false);
+
+    expect(
+      orchestrator.isDispatchEligible(
+        createIssue({
+          id: "todo-2",
+          identifier: "ISSUE-2",
+          state: "Todo",
+          blockedBy: [{ id: "b2", identifier: "B-2", state: "Done" }],
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("dispatches eligible issues on poll tick until slots are exhausted", async () => {
+    const orchestrator = createOrchestrator({
+      tracker: createTracker({
+        candidates: [
+          createIssue({ id: "1", identifier: "ISSUE-1", priority: 1 }),
+          createIssue({ id: "2", identifier: "ISSUE-2", priority: 2 }),
+        ],
+      }),
+    });
+
+    const result = await orchestrator.pollTick();
+
+    expect(result.validation.ok).toBe(true);
+    expect(result.dispatchedIssueIds).toEqual(["1", "2"]);
+    expect(Object.keys(orchestrator.getState().running)).toEqual(["1", "2"]);
+    expect([...orchestrator.getState().claimed]).toEqual(["1", "2"]);
+  });
+
+  it("updates running issue state during reconciliation", async () => {
+    const tracker = createTracker({
+      statesById: [
+        { id: "1", identifier: "ISSUE-1", state: "In Review" },
+      ],
+    });
+    const orchestrator = createOrchestrator({ tracker });
+
+    await orchestrator.pollTick();
+    const result = await orchestrator.pollTick();
+
+    expect(result.stopRequests).toEqual([]);
+    expect(orchestrator.getState().running["1"]?.issue.state).toBe("In Review");
+  });
+
+  it("requests stop without cleanup when a running issue becomes non-active", async () => {
+    const stopRequests: unknown[] = [];
+    const tracker = createTracker({
+      statesById: [
+        { id: "1", identifier: "ISSUE-1", state: "Backlog" },
+      ],
+    });
+    const orchestrator = createOrchestrator({
+      tracker,
+      stopRunningIssue: async (input) => {
+        stopRequests.push(input);
+      },
+    });
+
+    await orchestrator.pollTick();
+    const result = await orchestrator.pollTick();
+
+    expect(result.stopRequests).toEqual([
+      {
+        issueId: "1",
+        issueIdentifier: "ISSUE-1",
+        cleanupWorkspace: false,
+        reason: "inactive_state",
+      },
+    ]);
+    expect(stopRequests).toHaveLength(1);
+  });
+
+  it("requests stop with cleanup when a running issue becomes terminal", async () => {
+    const tracker = createTracker({
+      statesById: [
+        { id: "1", identifier: "ISSUE-1", state: "Done" },
+      ],
+    });
+    const orchestrator = createOrchestrator({ tracker });
+
+    await orchestrator.pollTick();
+    const result = await orchestrator.pollTick();
+
+    expect(result.stopRequests).toEqual([
+      {
+        issueId: "1",
+        issueIdentifier: "ISSUE-1",
+        cleanupWorkspace: true,
+        reason: "terminal_state",
+      },
+    ]);
+  });
+
+  it("treats reconciliation with no running issues as a no-op", async () => {
+    const tracker = createTracker({
+      candidates: [],
+      statesById: [],
+    });
+    const orchestrator = createOrchestrator({ tracker });
+
+    const result = await orchestrator.pollTick();
+
+    expect(result.stopRequests).toEqual([]);
+    expect(result.reconciliationFetchFailed).toBe(false);
+  });
+
+  it("schedules continuation retry after a normal worker exit", async () => {
+    const timers = createFakeTimerScheduler();
+    const orchestrator = createOrchestrator({ timerScheduler: timers });
+
+    await orchestrator.pollTick();
+    const retryEntry = orchestrator.onWorkerExit({
+      issueId: "1",
+      outcome: "normal",
+      endedAt: new Date("2026-03-06T00:00:05.000Z"),
+    });
+
+    expect(retryEntry).toMatchObject({
+      issueId: "1",
+      identifier: "ISSUE-1",
+      attempt: 1,
+      error: null,
+      dueAtMs: Date.parse("2026-03-06T00:00:06.000Z"),
+    });
+    expect(timers.scheduled[0]?.delayMs).toBe(1_000);
+  });
+
+  it("schedules exponential backoff retries for abnormal exits and caps the delay", async () => {
+    const timers = createFakeTimerScheduler();
+    const orchestrator = createOrchestrator({
+      timerScheduler: timers,
+      config: createConfig({
+        agent: { maxRetryBackoffMs: 30_000 },
+      }),
+    });
+
+    await orchestrator.pollTick();
+    const retryEntry = orchestrator.onWorkerExit({
+      issueId: "1",
+      outcome: "abnormal",
+      reason: "turn failed",
+    });
+
+    expect(retryEntry).toMatchObject({
+      issueId: "1",
+      identifier: "ISSUE-1",
+      attempt: 1,
+      error: "worker exited: turn failed",
+    });
+    expect(timers.scheduled[0]?.delayMs).toBe(10_000);
+    expect(computeFailureRetryDelayMs(3, 30_000)).toBe(30_000);
+  });
+
+  it("requeues retry timers when slots are exhausted", async () => {
+    const timers = createFakeTimerScheduler();
+    const tracker = createTracker({
+      candidates: [createIssue({ id: "1", identifier: "ISSUE-1" })],
+    });
+    const orchestrator = createOrchestrator({
+      tracker,
+      timerScheduler: timers,
+      config: createConfig({
+        agent: { maxConcurrentAgents: 0 },
+      }),
+    });
+
+    // Create a queued retry entry without dispatching the issue.
+    orchestrator.getState().claimed.add("1");
+    orchestrator.getState().retryAttempts["1"] = {
+      issueId: "1",
+      identifier: "ISSUE-1",
+      attempt: 1,
+      dueAtMs: Date.parse("2026-03-06T00:00:00.000Z"),
+      timerHandle: null,
+      error: "previous failure",
+    };
+
+    const result = await orchestrator.onRetryTimer("1");
+
+    expect(result.dispatched).toBe(false);
+    expect(result.released).toBe(false);
+    expect(result.retryEntry).toMatchObject({
+      issueId: "1",
+      attempt: 2,
+      identifier: "ISSUE-1",
+      error: "no available orchestrator slots",
+    });
+  });
+
+  it("requests stop for stalled sessions before tracker refresh", async () => {
+    const stopCalls: Array<{ issueId: string; reason: string }> = [];
+    const tracker = createTracker({
+      statesById: [{ id: "1", identifier: "ISSUE-1", state: "In Progress" }],
+    });
+    const orchestrator = createOrchestrator({
+      tracker,
+      now: () => new Date("2026-03-06T00:10:00.000Z"),
+      config: createConfig({
+        codex: { stallTimeoutMs: 60_000 },
+      }),
+      stopRunningIssue: async (input) => {
+        stopCalls.push({ issueId: input.issueId, reason: input.reason });
+      },
+    });
+
+    await orchestrator.pollTick();
+    orchestrator.getState().running["1"]!.startedAt = "2026-03-06T00:00:00.000Z";
+    const result = await orchestrator.pollTick();
+
+    expect(result.stopRequests).toContainEqual({
+      issueId: "1",
+      issueIdentifier: "ISSUE-1",
+      cleanupWorkspace: false,
+      reason: "stall_timeout",
+    });
+    expect(stopCalls).toContainEqual({
+      issueId: "1",
+      reason: "stall_timeout",
+    });
+  });
+});
+
+function createOrchestrator(overrides?: {
+  config?: ResolvedWorkflowConfig;
+  tracker?: IssueTracker;
+  timerScheduler?: ReturnType<typeof createFakeTimerScheduler>;
+  stopRunningIssue?: OrchestratorCoreOptions["stopRunningIssue"];
+  now?: () => Date;
+}) {
+  const tracker =
+    overrides?.tracker ??
+    createTracker({
+      candidates: [createIssue({ id: "1", identifier: "ISSUE-1" })],
+      statesById: [{ id: "1", identifier: "ISSUE-1", state: "In Progress" }],
+    });
+  const options: OrchestratorCoreOptions = {
+    config: overrides?.config ?? createConfig(),
+    tracker,
+    spawnWorker: async () => ({
+      workerHandle: { pid: 1001 },
+      monitorHandle: { ref: "monitor-1" },
+    }),
+    now: overrides?.now ?? (() => new Date("2026-03-06T00:00:05.000Z")),
+  };
+
+  if (overrides?.stopRunningIssue !== undefined) {
+    options.stopRunningIssue = overrides.stopRunningIssue;
+  }
+
+  if (overrides?.timerScheduler !== undefined) {
+    options.timerScheduler = overrides.timerScheduler;
+  }
+
+  return new OrchestratorCore(options);
+}
+
+function createTracker(input?: {
+  candidates?: Issue[];
+  statesById?: IssueStateSnapshot[];
+}): IssueTracker {
+  return {
+    async fetchCandidateIssues() {
+      return input?.candidates ?? [createIssue({ id: "1", identifier: "ISSUE-1" })];
+    },
+    async fetchIssuesByStates() {
+      return [];
+    },
+    async fetchIssueStatesByIds() {
+      return input?.statesById ?? [];
+    },
+  };
+}
+
+function createConfig(overrides?: {
+  agent?: Partial<ResolvedWorkflowConfig["agent"]>;
+  codex?: Partial<ResolvedWorkflowConfig["codex"]>;
+}): ResolvedWorkflowConfig {
+  return {
+    workflowPath: "/tmp/WORKFLOW.md",
+    promptTemplate: "Prompt",
+    tracker: {
+      kind: "linear",
+      endpoint: "https://api.linear.app/graphql",
+      apiKey: "token",
+      projectSlug: "project",
+      activeStates: ["Todo", "In Progress", "In Review"],
+      terminalStates: ["Done", "Canceled"],
+    },
+    polling: {
+      intervalMs: 30_000,
+    },
+    workspace: {
+      root: "/tmp/workspaces",
+    },
+    hooks: {
+      afterCreate: null,
+      beforeRun: null,
+      afterRun: null,
+      beforeRemove: null,
+      timeoutMs: 30_000,
+    },
+    agent: {
+      maxConcurrentAgents: 2,
+      maxTurns: 5,
+      maxRetryBackoffMs: 300_000,
+      maxConcurrentAgentsByState: {},
+      ...overrides?.agent,
+    },
+    codex: {
+      command: "codex-app-server",
+      approvalPolicy: "never",
+      threadSandbox: null,
+      turnSandboxPolicy: null,
+      turnTimeoutMs: 300_000,
+      readTimeoutMs: 30_000,
+      stallTimeoutMs: 300_000,
+      ...overrides?.codex,
+    },
+    server: {
+      port: null,
+    },
+  };
+}
+
+function createIssue(overrides?: Partial<Issue>): Issue {
+  return {
+    id: overrides?.id ?? "1",
+    identifier: overrides?.identifier ?? "ISSUE-1",
+    title: overrides?.title ?? "Example issue",
+    description: overrides?.description ?? null,
+    priority: overrides?.priority ?? 1,
+    state: overrides?.state ?? "In Progress",
+    branchName: overrides?.branchName ?? null,
+    url: overrides?.url ?? null,
+    labels: overrides?.labels ?? [],
+    blockedBy: overrides?.blockedBy ?? [],
+    createdAt: overrides?.createdAt ?? "2026-03-01T00:00:00.000Z",
+    updatedAt: overrides?.updatedAt ?? "2026-03-01T00:00:00.000Z",
+  };
+}
+
+function createFakeTimerScheduler() {
+  const scheduled: Array<{
+    callback: () => void;
+    delayMs: number;
+  }> = [];
+  return {
+    scheduled,
+    set(callback: () => void, delayMs: number) {
+      scheduled.push({ callback, delayMs });
+      return { callback, delayMs } as unknown as ReturnType<typeof setTimeout>;
+    },
+    clear() {},
+  };
+}


### PR DESCRIPTION
## Problem
Task 12 requires the orchestrator core state machine from the local implementation plan and the upstream Symphony spec.

## Scope
- add an `OrchestratorCore` module for poll tick, dispatch ordering, eligibility, retry scheduling, stall detection, and reconciliation
- export the orchestrator core from the package entrypoint
- add spec-aligned tests for task 12 behavior

## References
- IMPLEMENTATION_PLAN.md task 12
- SPEC.upstream.md sections 8.1-8.5, 16.2-16.6, 17.4

## Test Evidence
- `pnpm typecheck`
- `pnpm test`

## Notes
- no UX or generated artifact changes