### PR TITLE
Add agent runner

### DIFF
--- a/src/agent/prompt-builder.ts
+++ b/src/agent/prompt-builder.ts
@@ -33,6 +33,11 @@ export interface RenderPromptInput {
   attempt: number | null;
 }
 
+export interface BuildTurnPromptInput extends RenderPromptInput {
+  turnNumber: number;
+  maxTurns: number;
+}
+
 export function getEffectivePromptTemplate(promptTemplate: string): string {
   const trimmed = promptTemplate.trim();
 
@@ -52,6 +57,43 @@ export async function renderPrompt(input: RenderPromptInput): Promise<string> {
   } catch (error) {
     throw toPromptTemplateError(error);
   }
+}
+
+export async function buildTurnPrompt(
+  input: BuildTurnPromptInput,
+): Promise<string> {
+  if (input.turnNumber <= 1) {
+    return await renderPrompt(input);
+  }
+
+  return buildContinuationPrompt({
+    issue: input.issue,
+    attempt: input.attempt,
+    turnNumber: input.turnNumber,
+    maxTurns: input.maxTurns,
+  });
+}
+
+export function buildContinuationPrompt(input: {
+  issue: Issue;
+  attempt: number | null;
+  turnNumber: number;
+  maxTurns: number;
+}): string {
+  const attemptLine =
+    input.attempt === null
+      ? "This worker session started from the initial dispatch."
+      : `This worker session is running retry/continuation attempt ${input.attempt}.`;
+
+  return [
+    `Continue working on issue ${input.issue.identifier}: ${input.issue.title}.`,
+    `This is continuation turn ${input.turnNumber} of ${input.maxTurns} in the current worker session.`,
+    attemptLine,
+    `Current tracker state: ${input.issue.state}.`,
+    "Reuse the existing thread context and current workspace state.",
+    "Do not restate the original task prompt unless it is strictly needed.",
+    "Make the next best progress on the issue, then stop when this session has no further useful work to do.",
+  ].join("\n");
 }
 
 function toTemplateIssue(issue: Issue): Record<string, unknown> {

--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -1,0 +1,416 @@
+import {
+  CodexAppServerClient,
+  type CodexClientEvent,
+  type CodexDynamicTool,
+  type CodexTurnResult,
+} from "../codex/app-server-client.js";
+import { createLinearGraphqlDynamicTool } from "../codex/linear-graphql-tool.js";
+import type { ResolvedWorkflowConfig } from "../config/types.js";
+import {
+  type Issue,
+  type LiveSession,
+  type RunAttempt,
+  type RunAttemptPhase,
+  type Workspace,
+  createEmptyLiveSession,
+  normalizeIssueState,
+} from "../domain/model.js";
+import { applyCodexEventToSession } from "../logging/session-metrics.js";
+import type { IssueTracker } from "../tracker/tracker.js";
+import { WorkspaceHookRunner } from "../workspace/hooks.js";
+import { validateWorkspaceCwd } from "../workspace/path-safety.js";
+import { WorkspaceManager } from "../workspace/workspace-manager.js";
+import {
+  type BuildTurnPromptInput,
+  buildTurnPrompt,
+} from "./prompt-builder.js";
+
+export interface AgentRunnerEvent extends CodexClientEvent {
+  issueId: string;
+  issueIdentifier: string;
+  attempt: number | null;
+  workspacePath: string;
+  turnCount: number;
+}
+
+export interface AgentRunnerCodexClient {
+  startSession(input: {
+    prompt: string;
+    title: string;
+  }): Promise<CodexTurnResult>;
+  continueTurn(prompt: string, title: string): Promise<CodexTurnResult>;
+  close(): Promise<void>;
+}
+
+export interface AgentRunnerCodexClientFactoryInput {
+  command: string;
+  cwd: string;
+  approvalPolicy: unknown;
+  threadSandbox: unknown;
+  turnSandboxPolicy: unknown;
+  readTimeoutMs: number;
+  turnTimeoutMs: number;
+  stallTimeoutMs: number;
+  dynamicTools: CodexDynamicTool[];
+  onEvent: (event: CodexClientEvent) => void;
+}
+
+export interface AgentRunnerOptions {
+  config: ResolvedWorkflowConfig;
+  tracker: IssueTracker;
+  workspaceManager?: WorkspaceManager;
+  hooks?: WorkspaceHookRunner;
+  createCodexClient?: (
+    input: AgentRunnerCodexClientFactoryInput,
+  ) => AgentRunnerCodexClient;
+  fetchFn?: typeof fetch;
+  onEvent?: (event: AgentRunnerEvent) => void;
+}
+
+export interface AgentRunInput {
+  issue: Issue;
+  attempt: number | null;
+}
+
+export interface AgentRunResult {
+  issue: Issue;
+  workspace: Workspace;
+  runAttempt: RunAttempt;
+  liveSession: LiveSession;
+  turnsCompleted: number;
+  lastTurn: CodexTurnResult | null;
+  rateLimits: Record<string, unknown> | null;
+}
+
+export class AgentRunnerError extends Error {
+  readonly code: string | undefined;
+  readonly status: RunAttemptPhase;
+  readonly failedPhase: RunAttemptPhase;
+  readonly issue: Issue;
+  readonly workspace: Workspace | null;
+  readonly runAttempt: RunAttempt;
+  readonly liveSession: LiveSession;
+
+  constructor(input: {
+    message: string;
+    code?: string;
+    status: RunAttemptPhase;
+    failedPhase: RunAttemptPhase;
+    issue: Issue;
+    workspace: Workspace | null;
+    runAttempt: RunAttempt;
+    liveSession: LiveSession;
+    cause?: unknown;
+  }) {
+    super(input.message, { cause: input.cause });
+    this.name = "AgentRunnerError";
+    this.code = input.code;
+    this.status = input.status;
+    this.failedPhase = input.failedPhase;
+    this.issue = input.issue;
+    this.workspace = input.workspace;
+    this.runAttempt = input.runAttempt;
+    this.liveSession = input.liveSession;
+  }
+}
+
+export class AgentRunner {
+  private readonly config: ResolvedWorkflowConfig;
+
+  private readonly tracker: IssueTracker;
+
+  private readonly workspaceManager: WorkspaceManager;
+
+  private readonly hooks: WorkspaceHookRunner;
+
+  private readonly createCodexClient: (
+    input: AgentRunnerCodexClientFactoryInput,
+  ) => AgentRunnerCodexClient;
+
+  private readonly fetchFn: typeof fetch | undefined;
+
+  private readonly onEvent: ((event: AgentRunnerEvent) => void) | undefined;
+
+  constructor(options: AgentRunnerOptions) {
+    this.config = options.config;
+    this.tracker = options.tracker;
+    this.hooks =
+      options.hooks ??
+      new WorkspaceHookRunner({
+        config: options.config.hooks,
+      });
+    this.workspaceManager =
+      options.workspaceManager ??
+      new WorkspaceManager({
+        root: options.config.workspace.root,
+        hooks: this.hooks,
+      });
+    this.createCodexClient =
+      options.createCodexClient ?? createDefaultCodexClient;
+    this.fetchFn = options.fetchFn;
+    this.onEvent = options.onEvent;
+  }
+
+  async run(input: AgentRunInput): Promise<AgentRunResult> {
+    let issue = cloneIssue(input.issue);
+    let workspace: Workspace | null = null;
+    let client: AgentRunnerCodexClient | null = null;
+    let shouldRunAfterHook = false;
+    let lastTurn: CodexTurnResult | null = null;
+    let rateLimits: Record<string, unknown> | null = null;
+    const liveSession = createEmptyLiveSession();
+    const runAttempt: RunAttempt = {
+      issueId: issue.id,
+      issueIdentifier: issue.identifier,
+      attempt: input.attempt,
+      workspacePath: "",
+      startedAt: new Date().toISOString(),
+      status: "preparing_workspace",
+    };
+
+    try {
+      workspace = await this.workspaceManager.createForIssue(issue.identifier);
+      runAttempt.workspacePath = validateWorkspaceCwd({
+        cwd: workspace.path,
+        workspacePath: workspace.path,
+        workspaceRoot: this.config.workspace.root,
+      });
+      const workspacePath = workspace.path;
+
+      await this.hooks.run({
+        name: "beforeRun",
+        workspacePath: workspace.path,
+      });
+      shouldRunAfterHook = true;
+
+      runAttempt.status = "launching_agent_process";
+      client = this.createCodexClient({
+        command: this.config.codex.command,
+        cwd: workspace.path,
+        approvalPolicy: this.config.codex.approvalPolicy,
+        threadSandbox: this.config.codex.threadSandbox,
+        turnSandboxPolicy: this.config.codex.turnSandboxPolicy,
+        readTimeoutMs: this.config.codex.readTimeoutMs,
+        turnTimeoutMs: this.config.codex.turnTimeoutMs,
+        stallTimeoutMs: this.config.codex.stallTimeoutMs,
+        dynamicTools: this.createDynamicTools(),
+        onEvent: (event) => {
+          applyCodexEventToSession(liveSession, event);
+          this.onEvent?.({
+            ...event,
+            issueId: issue.id,
+            issueIdentifier: issue.identifier,
+            attempt: input.attempt,
+            workspacePath,
+            turnCount: liveSession.turnCount,
+          });
+        },
+      });
+
+      for (
+        let turnNumber = 1;
+        turnNumber <= this.config.agent.maxTurns;
+        turnNumber += 1
+      ) {
+        runAttempt.status = "building_prompt";
+        const prompt = await buildTurnPrompt({
+          workflow: {
+            promptTemplate: this.config.promptTemplate,
+          },
+          issue,
+          attempt: input.attempt,
+          turnNumber,
+          maxTurns: this.config.agent.maxTurns,
+        });
+        const title = `${issue.identifier}: ${issue.title}`;
+
+        runAttempt.status =
+          turnNumber === 1 ? "initializing_session" : "streaming_turn";
+        lastTurn =
+          turnNumber === 1
+            ? await client.startSession({ prompt, title })
+            : await client.continueTurn(prompt, title);
+        rateLimits = lastTurn.rateLimits;
+
+        applyCodexEventToSession(liveSession, {
+          event:
+            lastTurn.status === "completed"
+              ? "turn_completed"
+              : lastTurn.status === "failed"
+                ? "turn_failed"
+                : "turn_cancelled",
+          timestamp: new Date().toISOString(),
+          codexAppServerPid: liveSession.codexAppServerPid,
+          sessionId: lastTurn.sessionId,
+          threadId: lastTurn.threadId,
+          turnId: lastTurn.turnId,
+          ...(lastTurn.usage === null ? {} : { usage: lastTurn.usage }),
+          ...(lastTurn.rateLimits === null
+            ? {}
+            : { rateLimits: lastTurn.rateLimits }),
+          ...(lastTurn.message === null ? {} : { message: lastTurn.message }),
+        });
+
+        runAttempt.status = "finishing";
+        issue = await this.refreshIssueState(issue);
+        if (!this.isIssueStillActive(issue)) {
+          break;
+        }
+      }
+
+      runAttempt.status = "succeeded";
+
+      return {
+        issue,
+        workspace,
+        runAttempt,
+        liveSession,
+        turnsCompleted: liveSession.turnCount,
+        lastTurn,
+        rateLimits,
+      };
+    } catch (error) {
+      const wrapped = this.toAgentRunnerError({
+        error,
+        issue,
+        workspace,
+        runAttempt,
+        liveSession,
+      });
+      runAttempt.status = wrapped.status;
+      runAttempt.error = wrapped.message;
+      throw wrapped;
+    } finally {
+      if (client !== null) {
+        await closeBestEffort(client);
+      }
+
+      if (shouldRunAfterHook && workspace !== null) {
+        await this.hooks.runBestEffort({
+          name: "afterRun",
+          workspacePath: workspace.path,
+        });
+      }
+    }
+  }
+
+  private createDynamicTools(): CodexDynamicTool[] {
+    if (normalizeIssueState(this.config.tracker.kind ?? "") !== "linear") {
+      return [];
+    }
+
+    return [
+      createLinearGraphqlDynamicTool({
+        endpoint: this.config.tracker.endpoint,
+        apiKey: this.config.tracker.apiKey,
+        ...(this.fetchFn === undefined ? {} : { fetchFn: this.fetchFn }),
+      }),
+    ];
+  }
+
+  private async refreshIssueState(issue: Issue): Promise<Issue> {
+    const refreshed = await this.tracker.fetchIssueStatesByIds([issue.id]);
+    const next = refreshed[0];
+
+    if (next === undefined) {
+      return issue;
+    }
+
+    return {
+      ...issue,
+      identifier:
+        next.identifier.trim().length > 0 ? next.identifier : issue.identifier,
+      state: next.state,
+    };
+  }
+
+  private isIssueStillActive(issue: Issue): boolean {
+    const activeStates = new Set(
+      this.config.tracker.activeStates.map((state) =>
+        normalizeIssueState(state),
+      ),
+    );
+    return activeStates.has(normalizeIssueState(issue.state));
+  }
+
+  private toAgentRunnerError(input: {
+    error: unknown;
+    issue: Issue;
+    workspace: Workspace | null;
+    runAttempt: RunAttempt;
+    liveSession: LiveSession;
+  }): AgentRunnerError {
+    if (input.error instanceof AgentRunnerError) {
+      return input.error;
+    }
+
+    const message =
+      input.error instanceof Error ? input.error.message : "Agent run failed.";
+    const code =
+      typeof input.error === "object" &&
+      input.error !== null &&
+      "code" in input.error &&
+      typeof input.error.code === "string"
+        ? input.error.code
+        : undefined;
+
+    return new AgentRunnerError({
+      message,
+      ...(code === undefined ? {} : { code }),
+      status: classifyFailureStatus(code),
+      failedPhase: input.runAttempt.status,
+      issue: input.issue,
+      workspace: input.workspace,
+      runAttempt: { ...input.runAttempt },
+      liveSession: { ...input.liveSession },
+      cause: input.error,
+    });
+  }
+}
+
+function createDefaultCodexClient(
+  input: AgentRunnerCodexClientFactoryInput,
+): AgentRunnerCodexClient {
+  return new CodexAppServerClient({
+    command: input.command,
+    cwd: input.cwd,
+    approvalPolicy: input.approvalPolicy,
+    threadSandbox: input.threadSandbox,
+    turnSandboxPolicy: input.turnSandboxPolicy,
+    readTimeoutMs: input.readTimeoutMs,
+    turnTimeoutMs: input.turnTimeoutMs,
+    stallTimeoutMs: input.stallTimeoutMs,
+    dynamicTools: input.dynamicTools,
+    onEvent: input.onEvent,
+  });
+}
+
+function classifyFailureStatus(code: string | undefined): RunAttemptPhase {
+  if (code === "codex_turn_timeout" || code === "hook_timed_out") {
+    return "timed_out";
+  }
+
+  if (code === "codex_session_stalled") {
+    return "stalled";
+  }
+
+  return "failed";
+}
+
+async function closeBestEffort(client: AgentRunnerCodexClient): Promise<void> {
+  try {
+    await client.close();
+  } catch {
+    // Closing is cleanup-only here; preserve the primary failure cause.
+  }
+}
+
+function cloneIssue(issue: Issue): Issue {
+  return {
+    ...issue,
+    labels: [...issue.labels],
+    blockedBy: issue.blockedBy.map((blocker) => ({ ...blocker })),
+  };
+}
+
+export type { BuildTurnPromptInput };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./agent/prompt-builder.js";
+export * from "./agent/runner.js";
 export * from "./config/defaults.js";
 export * from "./config/config-resolver.js";
 export * from "./config/types.js";

--- a/src/orchestrator/core.ts
+++ b/src/orchestrator/core.ts
@@ -1,18 +1,18 @@
-import {
-  createEmptyLiveSession,
-  createInitialOrchestratorState,
-  normalizeIssueState,
-  type Issue,
-  type OrchestratorState,
-  type RetryEntry,
-  type RunningEntry,
-} from "../domain/model.js";
-import { addEndedSessionRuntime } from "../logging/session-metrics.js";
 import { validateDispatchConfig } from "../config/config-resolver.js";
 import type {
   DispatchValidationResult,
   ResolvedWorkflowConfig,
 } from "../config/types.js";
+import {
+  type Issue,
+  type OrchestratorState,
+  type RetryEntry,
+  type RunningEntry,
+  createEmptyLiveSession,
+  createInitialOrchestratorState,
+  normalizeIssueState,
+} from "../domain/model.js";
+import { addEndedSessionRuntime } from "../logging/session-metrics.js";
 import type { IssueStateSnapshot, IssueTracker } from "../tracker/tracker.js";
 
 const CONTINUATION_RETRY_DELAY_MS = 1_000;
@@ -20,10 +20,7 @@ const FAILURE_RETRY_BASE_DELAY_MS = 10_000;
 
 export type WorkerExitOutcome = "normal" | "abnormal";
 
-export type StopReason =
-  | "terminal_state"
-  | "inactive_state"
-  | "stall_timeout";
+export type StopReason = "terminal_state" | "inactive_state" | "stall_timeout";
 
 export interface SpawnWorkerResult {
   workerHandle: unknown;
@@ -149,7 +146,10 @@ export class OrchestratorCore {
       return false;
     }
 
-    if (this.availableSlots() <= 0 || this.availableSlotsForState(issue.state) <= 0) {
+    if (
+      this.availableSlots() <= 0 ||
+      this.availableSlotsForState(issue.state) <= 0
+    ) {
       return false;
     }
 
@@ -158,7 +158,8 @@ export class OrchestratorCore {
     }
 
     return issue.blockedBy.every((blocker) => {
-      const blockerState = blocker.state === null ? null : normalizeIssueState(blocker.state);
+      const blockerState =
+        blocker.state === null ? null : normalizeIssueState(blocker.state);
       return blockerState !== null && terminalStates.has(blockerState);
     });
   }
@@ -243,7 +244,8 @@ export class OrchestratorCore {
       };
     }
 
-    const issue = candidates.find((candidate) => candidate.id === issueId) ?? null;
+    const issue =
+      candidates.find((candidate) => candidate.id === issueId) ?? null;
     if (issue === null) {
       this.releaseClaim(issueId);
       return {
@@ -262,7 +264,10 @@ export class OrchestratorCore {
       };
     }
 
-    if (this.availableSlots() <= 0 || this.availableSlotsForState(issue.state) <= 0) {
+    if (
+      this.availableSlots() <= 0 ||
+      this.availableSlotsForState(issue.state) <= 0
+    ) {
       return {
         dispatched: false,
         released: false,
@@ -294,7 +299,11 @@ export class OrchestratorCore {
     }
 
     delete this.state.running[input.issueId];
-    addEndedSessionRuntime(this.state, runningEntry.startedAt, input.endedAt ?? this.now());
+    addEndedSessionRuntime(
+      this.state,
+      runningEntry.startedAt,
+      input.endedAt ?? this.now(),
+    );
 
     if (input.outcome === "normal") {
       this.state.completed.add(input.issueId);
@@ -425,7 +434,9 @@ export class OrchestratorCore {
     }
 
     const activeStates = toNormalizedStateSet(this.config.tracker.activeStates);
-    const terminalStates = toNormalizedStateSet(this.config.tracker.terminalStates);
+    const terminalStates = toNormalizedStateSet(
+      this.config.tracker.terminalStates,
+    );
 
     for (const snapshot of refreshed) {
       const runningEntry = this.state.running[snapshot.id];
@@ -563,12 +574,14 @@ export class OrchestratorCore {
 
 export function sortIssuesForDispatch(issues: readonly Issue[]): Issue[] {
   return issues.slice().sort((left, right) => {
-    const priorityDelta = toSortablePriority(left.priority) - toSortablePriority(right.priority);
+    const priorityDelta =
+      toSortablePriority(left.priority) - toSortablePriority(right.priority);
     if (priorityDelta !== 0) {
       return priorityDelta;
     }
 
-    const createdAtDelta = toSortableDate(left.createdAt) - toSortableDate(right.createdAt);
+    const createdAtDelta =
+      toSortableDate(left.createdAt) - toSortableDate(right.createdAt);
     if (createdAtDelta !== 0) {
       return createdAtDelta;
     }

--- a/tests/agent/prompt-builder.test.ts
+++ b/tests/agent/prompt-builder.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "vitest";
 
 import {
   DEFAULT_WORKFLOW_PROMPT,
+  buildContinuationPrompt,
+  buildTurnPrompt,
   getEffectivePromptTemplate,
   renderPrompt,
 } from "../../src/agent/prompt-builder.js";
@@ -68,6 +70,46 @@ describe("prompt builder", () => {
     });
 
     expect(prompt).toBe("first-run");
+  });
+
+  it("uses the rendered workflow prompt for the first turn and continuation guidance after that", async () => {
+    const first = await buildTurnPrompt({
+      workflow: {
+        promptTemplate: "Initial {{ issue.identifier }} attempt={{ attempt }}",
+      },
+      issue: ISSUE_FIXTURE,
+      attempt: 3,
+      turnNumber: 1,
+      maxTurns: 4,
+    });
+    const second = await buildTurnPrompt({
+      workflow: {
+        promptTemplate: "Initial {{ issue.identifier }} attempt={{ attempt }}",
+      },
+      issue: ISSUE_FIXTURE,
+      attempt: 3,
+      turnNumber: 2,
+      maxTurns: 4,
+    });
+
+    expect(first).toBe("Initial ABC-123 attempt=3");
+    expect(second).toContain("Continue working on issue ABC-123");
+    expect(second).toContain("continuation turn 2 of 4");
+    expect(second).not.toContain("Initial ABC-123 attempt=3");
+  });
+
+  it("builds continuation guidance with issue and attempt context", () => {
+    const prompt = buildContinuationPrompt({
+      issue: ISSUE_FIXTURE,
+      attempt: null,
+      turnNumber: 2,
+      maxTurns: 5,
+    });
+
+    expect(prompt).toContain("ABC-123");
+    expect(prompt).toContain("Ship prompt rendering");
+    expect(prompt).toContain("Current tracker state: In Progress.");
+    expect(prompt).toContain("initial dispatch");
   });
 
   it("fails on unknown variables in strict mode", async () => {

--- a/tests/agent/runner.test.ts
+++ b/tests/agent/runner.test.ts
@@ -1,0 +1,379 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { ResolvedWorkflowConfig } from "../../src/config/types.js";
+import type { Issue } from "../../src/domain/model.js";
+import { ERROR_CODES } from "../../src/errors/codes.js";
+import {
+  AgentRunner,
+  type AgentRunnerCodexClientFactoryInput,
+  type AgentRunnerError,
+  WorkspaceHookError,
+} from "../../src/index.js";
+import type {
+  IssueStateSnapshot,
+  IssueTracker,
+} from "../../src/tracker/tracker.js";
+
+const fixturePath = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "../fixtures/codex-fake-server.mjs",
+);
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  await Promise.allSettled(
+    roots.splice(0).map(async (root) => {
+      await rm(root, { recursive: true, force: true });
+    }),
+  );
+});
+
+describe("AgentRunner", () => {
+  it("runs a single issue through workspace setup, dynamic Linear tool injection, continuation turns, and state refresh", async () => {
+    const root = await createRoot();
+    const tracker = createTracker({
+      refreshStates: [
+        { id: "issue-1", identifier: "ABC-123", state: "In Progress" },
+        { id: "issue-1", identifier: "ABC-123", state: "Done" },
+      ],
+    });
+    const fetchFn = vi.fn<typeof fetch>().mockResolvedValue(
+      jsonResponse({
+        data: {
+          viewer: {
+            id: "viewer-1",
+            name: "Example User",
+          },
+        },
+      }),
+    );
+    const events: Array<{
+      event: string;
+      workspacePath: string;
+      turnCount: number;
+    }> = [];
+    const runner = new AgentRunner({
+      config: createConfig(root, "linear-tool"),
+      tracker,
+      fetchFn,
+      onEvent: (event) => {
+        events.push({
+          event: event.event,
+          workspacePath: event.workspacePath,
+          turnCount: event.turnCount,
+        });
+      },
+    });
+
+    const result = await runner.run({
+      issue: ISSUE_FIXTURE,
+      attempt: null,
+    });
+
+    expect(result.runAttempt.status).toBe("succeeded");
+    expect(result.workspace.createdNow).toBe(true);
+    expect(result.turnsCompleted).toBe(2);
+    expect(result.issue.state).toBe("Done");
+    expect(result.liveSession.threadId).toBe("thread-1");
+    expect(result.liveSession.turnId).toBe("turn-2");
+    expect(result.liveSession.turnCount).toBe(2);
+    expect(result.rateLimits).toEqual({
+      requests_remaining: 9,
+      tokens_remaining: 999,
+    });
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+    expect(tracker.fetchIssueStatesByIds).toHaveBeenCalledTimes(2);
+    expect(events.map((event) => event.event)).toContain("turn_completed");
+    expect(events.at(-1)).toEqual(
+      expect.objectContaining({
+        workspacePath: result.workspace.path,
+        turnCount: 2,
+      }),
+    );
+  });
+
+  it("sends the rendered workflow prompt first and continuation guidance afterwards", async () => {
+    const root = await createRoot();
+    const prompts: string[] = [];
+    const tracker = createTracker({
+      refreshStates: [
+        { id: "issue-1", identifier: "ABC-123", state: "In Progress" },
+        { id: "issue-1", identifier: "ABC-123", state: "Human Review" },
+      ],
+    });
+    const runner = new AgentRunner({
+      config: createConfig(root, "unused"),
+      tracker,
+      createCodexClient: (input) =>
+        createStubCodexClient(prompts, input, {
+          statuses: ["completed", "completed"],
+        }),
+    });
+
+    const result = await runner.run({
+      issue: ISSUE_FIXTURE,
+      attempt: 2,
+    });
+
+    expect(result.turnsCompleted).toBe(2);
+    expect(prompts[0]).toBe("Initial prompt for ABC-123 attempt=2");
+    expect(prompts[1]).toContain("Continue working on issue ABC-123");
+    expect(prompts[1]).toContain("continuation turn 2 of 3");
+    expect(prompts[1]).not.toContain("Initial prompt for ABC-123 attempt=2");
+  });
+
+  it("fails immediately when before_run fails and does not invoke after_run", async () => {
+    const root = await createRoot();
+    const hooks = {
+      run: vi.fn(async ({ name }: { name: string }) => {
+        if (name !== "beforeRun") {
+          return false;
+        }
+
+        throw new WorkspaceHookError({
+          code: ERROR_CODES.hookFailed,
+          message: "before_run hook failed",
+          hook: "beforeRun",
+          workspacePath: join(root, "ABC-123"),
+          exitCode: 1,
+        });
+      }),
+      runBestEffort: vi.fn(),
+    };
+    const createCodexClient = vi.fn();
+    const runner = new AgentRunner({
+      config: createConfig(root, "unused"),
+      tracker: createTracker(),
+      hooks: hooks as never,
+      createCodexClient,
+    });
+
+    await expect(
+      runner.run({
+        issue: ISSUE_FIXTURE,
+        attempt: null,
+      }),
+    ).rejects.toMatchObject({
+      name: "AgentRunnerError",
+      code: ERROR_CODES.hookFailed,
+      status: "failed",
+      failedPhase: "preparing_workspace",
+    } satisfies Partial<AgentRunnerError>);
+
+    expect(createCodexClient).not.toHaveBeenCalled();
+    expect(hooks.runBestEffort).not.toHaveBeenCalled();
+  });
+
+  it("closes the session and still runs after_run best-effort when refresh fails", async () => {
+    const root = await createRoot();
+    const close = vi.fn().mockResolvedValue(undefined);
+    const hooks = {
+      run: vi.fn().mockResolvedValue(true),
+      runBestEffort: vi.fn().mockResolvedValue(false),
+    };
+    const runner = new AgentRunner({
+      config: createConfig(root, "unused"),
+      tracker: {
+        fetchCandidateIssues: vi.fn(),
+        fetchIssuesByStates: vi.fn(),
+        fetchIssueStatesByIds: vi
+          .fn()
+          .mockRejectedValue(new Error("refresh failed")),
+      },
+      hooks: hooks as never,
+      createCodexClient: (input) =>
+        createStubCodexClient([], input, {
+          close,
+          statuses: ["completed"],
+        }),
+    });
+
+    await expect(
+      runner.run({
+        issue: ISSUE_FIXTURE,
+        attempt: null,
+      }),
+    ).rejects.toMatchObject({
+      name: "AgentRunnerError",
+      status: "failed",
+      failedPhase: "finishing",
+      message: "refresh failed",
+    } satisfies Partial<AgentRunnerError>);
+
+    expect(close).toHaveBeenCalledTimes(1);
+    expect(hooks.runBestEffort).toHaveBeenCalledWith({
+      name: "afterRun",
+      workspacePath: expect.stringContaining("ABC-123"),
+    });
+  });
+});
+
+function createStubCodexClient(
+  prompts: string[],
+  input: AgentRunnerCodexClientFactoryInput,
+  overrides?: Partial<{
+    close: ReturnType<typeof vi.fn>;
+    statuses: Array<"completed" | "failed" | "cancelled">;
+  }>,
+) {
+  let turn = 0;
+  const statuses = overrides?.statuses ?? ["completed"];
+
+  return {
+    async startSession({ prompt }: { prompt: string; title: string }) {
+      turn += 1;
+      prompts.push(prompt);
+      input.onEvent({
+        event: "session_started",
+        timestamp: new Date("2026-03-06T00:00:00.000Z").toISOString(),
+        codexAppServerPid: "1001",
+        sessionId: `thread-1-turn-${turn}`,
+        threadId: "thread-1",
+        turnId: `turn-${turn}`,
+      });
+      return {
+        status: statuses[turn - 1] ?? "completed",
+        threadId: "thread-1",
+        turnId: `turn-${turn}`,
+        sessionId: `thread-1-turn-${turn}`,
+        usage: {
+          inputTokens: 10 * turn,
+          outputTokens: 5 * turn,
+          totalTokens: 15 * turn,
+        },
+        rateLimits: {
+          requestsRemaining: 10 - turn,
+        },
+        message: `turn ${turn}`,
+      };
+    },
+    async continueTurn(prompt: string) {
+      turn += 1;
+      prompts.push(prompt);
+      input.onEvent({
+        event: "session_started",
+        timestamp: new Date("2026-03-06T00:00:00.000Z").toISOString(),
+        codexAppServerPid: "1001",
+        sessionId: `thread-1-turn-${turn}`,
+        threadId: "thread-1",
+        turnId: `turn-${turn}`,
+      });
+      return {
+        status: statuses[turn - 1] ?? "completed",
+        threadId: "thread-1",
+        turnId: `turn-${turn}`,
+        sessionId: `thread-1-turn-${turn}`,
+        usage: {
+          inputTokens: 10 * turn,
+          outputTokens: 5 * turn,
+          totalTokens: 15 * turn,
+        },
+        rateLimits: {
+          requestsRemaining: 10 - turn,
+        },
+        message: `turn ${turn}`,
+      };
+    },
+    close: overrides?.close ?? vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+function createTracker(input?: {
+  refreshStates?: IssueStateSnapshot[];
+}): IssueTracker {
+  const refreshStates = [...(input?.refreshStates ?? [])];
+
+  return {
+    fetchCandidateIssues: vi.fn(),
+    fetchIssuesByStates: vi.fn(),
+    fetchIssueStatesByIds: vi.fn(async () => {
+      const next = refreshStates.shift();
+      return next === undefined ? [] : [next];
+    }),
+  };
+}
+
+function createConfig(root: string, scenario: string): ResolvedWorkflowConfig {
+  return {
+    workflowPath: join(root, "WORKFLOW.md"),
+    promptTemplate:
+      "Initial prompt for {{ issue.identifier }} attempt={{ attempt }}",
+    tracker: {
+      kind: "linear",
+      endpoint: "https://api.linear.app/graphql",
+      apiKey: "linear-token",
+      projectSlug: "example",
+      activeStates: ["In Progress"],
+      terminalStates: ["Done", "Canceled"],
+    },
+    polling: {
+      intervalMs: 30_000,
+    },
+    workspace: {
+      root,
+    },
+    hooks: {
+      afterCreate: null,
+      beforeRun: null,
+      afterRun: null,
+      beforeRemove: null,
+      timeoutMs: 500,
+    },
+    agent: {
+      maxConcurrentAgents: 2,
+      maxTurns: 3,
+      maxRetryBackoffMs: 300_000,
+      maxConcurrentAgentsByState: {},
+    },
+    codex: {
+      command: `${process.execPath} "${fixturePath}" ${scenario}`,
+      approvalPolicy: "full-auto",
+      threadSandbox: "workspace-write",
+      turnSandboxPolicy: {
+        type: "workspace-write",
+      },
+      turnTimeoutMs: 1_000,
+      readTimeoutMs: 1_000,
+      stallTimeoutMs: 2_000,
+    },
+    server: {
+      port: null,
+    },
+  };
+}
+
+async function createRoot(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "symphony-task11-"));
+  roots.push(root);
+  return root;
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      "content-type": "application/json",
+    },
+  });
+}
+
+const ISSUE_FIXTURE: Issue = {
+  id: "issue-1",
+  identifier: "ABC-123",
+  title: "Ship agent runner",
+  description: "Implement the runner",
+  priority: 1,
+  state: "In Progress",
+  branchName: null,
+  url: "https://linear.app/example/issue/ABC-123",
+  labels: ["automation"],
+  blockedBy: [],
+  createdAt: "2026-03-06T00:00:00.000Z",
+  updatedAt: "2026-03-06T01:00:00.000Z",
+};

--- a/tests/orchestrator/core.test.ts
+++ b/tests/orchestrator/core.test.ts
@@ -1,14 +1,17 @@
 import { describe, expect, it } from "vitest";
 
+import type { ResolvedWorkflowConfig } from "../../src/config/types.js";
 import type { Issue } from "../../src/domain/model.js";
 import {
   OrchestratorCore,
+  type OrchestratorCoreOptions,
   computeFailureRetryDelayMs,
   sortIssuesForDispatch,
-  type OrchestratorCoreOptions,
 } from "../../src/orchestrator/core.js";
-import type { ResolvedWorkflowConfig } from "../../src/config/types.js";
-import type { IssueStateSnapshot, IssueTracker } from "../../src/tracker/tracker.js";
+import type {
+  IssueStateSnapshot,
+  IssueTracker,
+} from "../../src/tracker/tracker.js";
 
 describe("orchestrator core", () => {
   it("sorts dispatch candidates by priority, age, and identifier", () => {
@@ -82,9 +85,7 @@ describe("orchestrator core", () => {
 
   it("updates running issue state during reconciliation", async () => {
     const tracker = createTracker({
-      statesById: [
-        { id: "1", identifier: "ISSUE-1", state: "In Review" },
-      ],
+      statesById: [{ id: "1", identifier: "ISSUE-1", state: "In Review" }],
     });
     const orchestrator = createOrchestrator({ tracker });
 
@@ -98,9 +99,7 @@ describe("orchestrator core", () => {
   it("requests stop without cleanup when a running issue becomes non-active", async () => {
     const stopRequests: unknown[] = [];
     const tracker = createTracker({
-      statesById: [
-        { id: "1", identifier: "ISSUE-1", state: "Backlog" },
-      ],
+      statesById: [{ id: "1", identifier: "ISSUE-1", state: "Backlog" }],
     });
     const orchestrator = createOrchestrator({
       tracker,
@@ -125,9 +124,7 @@ describe("orchestrator core", () => {
 
   it("requests stop with cleanup when a running issue becomes terminal", async () => {
     const tracker = createTracker({
-      statesById: [
-        { id: "1", identifier: "ISSUE-1", state: "Done" },
-      ],
+      statesById: [{ id: "1", identifier: "ISSUE-1", state: "Done" }],
     });
     const orchestrator = createOrchestrator({ tracker });
 
@@ -257,7 +254,12 @@ describe("orchestrator core", () => {
     });
 
     await orchestrator.pollTick();
-    orchestrator.getState().running["1"]!.startedAt = "2026-03-06T00:00:00.000Z";
+    const runningEntry = orchestrator.getState().running["1"];
+    expect(runningEntry).toBeDefined();
+    if (runningEntry === undefined) {
+      throw new Error("Expected issue 1 to be running.");
+    }
+    runningEntry.startedAt = "2026-03-06T00:00:00.000Z";
     const result = await orchestrator.pollTick();
 
     expect(result.stopRequests).toContainEqual({
@@ -313,7 +315,9 @@ function createTracker(input?: {
 }): IssueTracker {
   return {
     async fetchCandidateIssues() {
-      return input?.candidates ?? [createIssue({ id: "1", identifier: "ISSUE-1" })];
+      return (
+        input?.candidates ?? [createIssue({ id: "1", identifier: "ISSUE-1" })]
+      );
     },
     async fetchIssuesByStates() {
       return [];


### PR DESCRIPTION
## Summary
- add the task 11 agent runner that composes workspace setup, hooks, prompt building, Codex session lifecycle, continuation turns, and post-turn tracker refresh
- add prompt-builder support for continuation guidance and export the new runner API
- add runner integration coverage and clean up inherited task-12 lint issues needed for a clean branch

## References
- IMPLEMENTATION_PLAN.md task 11 Agent runner
- SPEC.upstream.md Section 10 Agent Runner Protocol

## Testing
- pnpm typecheck
- pnpm lint
- pnpm test -- --run tests/agent/prompt-builder.test.ts tests/agent/runner.test.ts tests/codex/app-server-client.test.ts tests/orchestrator/core.test.ts