### PR TITLE
Add observability dashboard server

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ export * from "./logging/fields.js";
 export * from "./logging/runtime-snapshot.js";
 export * from "./logging/session-metrics.js";
 export * from "./logging/structured-logger.js";
+export * from "./observability/dashboard-server.js";
 export * from "./orchestrator/core.js";
 export * from "./workspace/hooks.js";
 export * from "./tracker/errors.js";

--- a/src/observability/dashboard-server.ts
+++ b/src/observability/dashboard-server.ts
@@ -1,0 +1,478 @@
+import {
+  type IncomingMessage,
+  type Server,
+  type ServerResponse,
+  createServer,
+} from "node:http";
+
+import { ERROR_CODES } from "../errors/codes.js";
+import type { RuntimeSnapshot } from "../logging/runtime-snapshot.js";
+
+export interface IssueDetailRunningState {
+  session_id: string | null;
+  turn_count: number;
+  state: string;
+  started_at: string;
+  last_event: string | null;
+  last_message: string | null;
+  last_event_at: string | null;
+  tokens: {
+    input_tokens: number;
+    output_tokens: number;
+    total_tokens: number;
+  };
+}
+
+export interface IssueDetailRetryState {
+  attempt: number;
+  due_at: string;
+  error: string | null;
+}
+
+export interface IssueDetailResponse {
+  issue_identifier: string;
+  issue_id: string;
+  status: "claimed" | "released" | "retry_queued" | "running" | "unclaimed";
+  workspace: {
+    path: string;
+  } | null;
+  attempts: {
+    restart_count: number;
+    current_retry_attempt: number | null;
+  };
+  running: IssueDetailRunningState | null;
+  retry: IssueDetailRetryState | null;
+  logs: {
+    codex_session_logs: Array<{
+      label: string;
+      path: string;
+      url: string | null;
+    }>;
+  };
+  recent_events: Array<{
+    at: string;
+    event: string;
+    message: string | null;
+  }>;
+  last_error: string | null;
+  tracked: Record<string, unknown>;
+}
+
+export interface RefreshResponse {
+  queued: boolean;
+  coalesced: boolean;
+  requested_at: string;
+  operations: string[];
+}
+
+export interface DashboardServerHost {
+  getRuntimeSnapshot(): RuntimeSnapshot | Promise<RuntimeSnapshot>;
+  getIssueDetails(
+    issueIdentifier: string,
+  ): IssueDetailResponse | null | Promise<IssueDetailResponse | null>;
+  requestRefresh(): RefreshResponse | Promise<RefreshResponse>;
+}
+
+export interface DashboardServerOptions {
+  host: DashboardServerHost;
+  hostname?: string;
+}
+
+export interface DashboardServerInstance {
+  readonly server: Server;
+  readonly hostname: string;
+  readonly port: number;
+  close(): Promise<void>;
+}
+
+export function createDashboardServer(options: DashboardServerOptions): Server {
+  const hostname = options.hostname ?? "127.0.0.1";
+  const handler = createDashboardRequestHandler({
+    host: options.host,
+    hostname,
+  });
+  return createServer((request, response) => {
+    void handler(request, response);
+  });
+}
+
+export async function startDashboardServer(
+  options: DashboardServerOptions & {
+    port: number;
+  },
+): Promise<DashboardServerInstance> {
+  const server = createDashboardServer(options);
+  const hostname = options.hostname ?? "127.0.0.1";
+
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(options.port, hostname, () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+
+  const address = server.address();
+  if (address === null || typeof address === "string") {
+    throw new Error("Dashboard server did not bind to a TCP address.");
+  }
+
+  return {
+    server,
+    hostname,
+    port: address.port,
+    close: async () => {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+
+          resolve();
+        });
+      });
+    },
+  };
+}
+
+export function createDashboardRequestHandler(
+  options: DashboardServerOptions,
+): (request: IncomingMessage, response: ServerResponse) => Promise<void> {
+  const hostname = options.hostname ?? "127.0.0.1";
+
+  return async (request, response) => {
+    try {
+      const url = new URL(request.url ?? "/", `http://${hostname}`);
+      const method = request.method ?? "GET";
+
+      if (url.pathname === "/") {
+        if (method !== "GET") {
+          writeMethodNotAllowed(response, ["GET"]);
+          return;
+        }
+
+        const snapshot = await options.host.getRuntimeSnapshot();
+        writeHtml(response, 200, renderDashboardHtml(snapshot));
+        return;
+      }
+
+      if (url.pathname === "/api/v1/state") {
+        if (method !== "GET") {
+          writeMethodNotAllowed(response, ["GET"]);
+          return;
+        }
+
+        const snapshot = await options.host.getRuntimeSnapshot();
+        writeJson(response, 200, snapshot);
+        return;
+      }
+
+      if (url.pathname === "/api/v1/refresh") {
+        if (method !== "POST") {
+          writeMethodNotAllowed(response, ["POST"]);
+          return;
+        }
+
+        await readRequestBody(request);
+        const refresh = await options.host.requestRefresh();
+        writeJson(response, 202, refresh);
+        return;
+      }
+
+      if (url.pathname.startsWith("/api/v1/")) {
+        if (method !== "GET") {
+          writeMethodNotAllowed(response, ["GET"]);
+          return;
+        }
+
+        const issueIdentifier = decodeURIComponent(
+          url.pathname.slice("/api/v1/".length),
+        );
+        const issue = await options.host.getIssueDetails(issueIdentifier);
+        if (issue === null) {
+          writeJsonError(response, 404, ERROR_CODES.issueNotFound, {
+            message: `Issue '${issueIdentifier}' is not tracked in the current runtime state.`,
+          });
+          return;
+        }
+
+        writeJson(response, 200, issue);
+        return;
+      }
+
+      writeNotFound(response, url.pathname);
+    } catch (error) {
+      writeJsonError(response, 500, ERROR_CODES.snapshotUnavailable, {
+        message: toErrorMessage(error),
+      });
+    }
+  };
+}
+
+function writeJson(
+  response: ServerResponse,
+  statusCode: number,
+  payload: unknown,
+): void {
+  const body = JSON.stringify(payload);
+  response.statusCode = statusCode;
+  response.setHeader("content-type", "application/json; charset=utf-8");
+  response.setHeader("content-length", Buffer.byteLength(body));
+  response.end(body);
+}
+
+function writeJsonError(
+  response: ServerResponse,
+  statusCode: number,
+  code: string,
+  input: {
+    message: string;
+    allow?: string[];
+  },
+): void {
+  if (input.allow !== undefined) {
+    response.setHeader("allow", input.allow.join(", "));
+  }
+
+  writeJson(response, statusCode, {
+    error: {
+      code,
+      message: input.message,
+    },
+  });
+}
+
+function writeMethodNotAllowed(
+  response: ServerResponse,
+  allow: string[],
+): void {
+  writeJsonError(response, 405, "method_not_allowed", {
+    message: "Method not allowed.",
+    allow,
+  });
+}
+
+function writeHtml(
+  response: ServerResponse,
+  statusCode: number,
+  html: string,
+): void {
+  response.statusCode = statusCode;
+  response.setHeader("content-type", "text/html; charset=utf-8");
+  response.setHeader("content-length", Buffer.byteLength(html));
+  response.end(html);
+}
+
+function writeNotFound(response: ServerResponse, path: string): void {
+  response.statusCode = 404;
+  response.setHeader("content-type", "text/plain; charset=utf-8");
+  response.end(`Not found: ${path}`);
+}
+
+async function readRequestBody(request: IncomingMessage): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    request.on("error", reject);
+    request.on("end", resolve);
+    request.resume();
+  });
+}
+
+function renderDashboardHtml(snapshot: RuntimeSnapshot): string {
+  const runningRows =
+    snapshot.running.length === 0
+      ? '<tr><td colspan="7">No active sessions.</td></tr>'
+      : snapshot.running
+          .map(
+            (row) => `
+              <tr>
+                <td>${escapeHtml(row.issue_identifier)}</td>
+                <td>${escapeHtml(row.state)}</td>
+                <td>${escapeHtml(row.session_id ?? "-")}</td>
+                <td>${row.turn_count}</td>
+                <td>${escapeHtml(row.last_event ?? "-")}</td>
+                <td>${escapeHtml(row.last_message ?? "-")}</td>
+                <td>${escapeHtml(row.last_event_at ?? "-")}</td>
+              </tr>`,
+          )
+          .join("");
+
+  const retryRows =
+    snapshot.retrying.length === 0
+      ? '<tr><td colspan="4">No queued retries.</td></tr>'
+      : snapshot.retrying
+          .map(
+            (row) => `
+              <tr>
+                <td>${escapeHtml(row.issue_identifier ?? row.issue_id)}</td>
+                <td>${row.attempt}</td>
+                <td>${escapeHtml(row.due_at)}</td>
+                <td>${escapeHtml(row.error ?? "-")}</td>
+              </tr>`,
+          )
+          .join("");
+
+  return `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Symphony Dashboard</title>
+    <style>
+      :root {
+        color-scheme: light;
+        font-family: ui-sans-serif, system-ui, sans-serif;
+        background: #f4efe7;
+        color: #1e1b18;
+      }
+      body {
+        margin: 0;
+        padding: 24px;
+        background:
+          radial-gradient(circle at top left, rgba(198, 110, 66, 0.16), transparent 28rem),
+          linear-gradient(180deg, #f8f3eb 0%, #efe4d3 100%);
+      }
+      main {
+        max-width: 1100px;
+        margin: 0 auto;
+      }
+      h1, h2 {
+        margin: 0 0 12px;
+      }
+      .grid {
+        display: grid;
+        gap: 16px;
+        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+        margin: 20px 0 28px;
+      }
+      .card, section {
+        background: rgba(255, 252, 247, 0.9);
+        border: 1px solid rgba(59, 44, 32, 0.12);
+        border-radius: 16px;
+        box-shadow: 0 10px 30px rgba(74, 46, 20, 0.08);
+      }
+      .card {
+        padding: 18px;
+      }
+      .metric {
+        font-size: 2rem;
+        font-weight: 700;
+      }
+      section {
+        padding: 20px;
+        margin-bottom: 18px;
+      }
+      table {
+        width: 100%;
+        border-collapse: collapse;
+      }
+      th, td {
+        text-align: left;
+        padding: 10px 8px;
+        border-bottom: 1px solid rgba(59, 44, 32, 0.12);
+        vertical-align: top;
+      }
+      th {
+        font-size: 0.875rem;
+        color: #5f5449;
+      }
+      pre {
+        white-space: pre-wrap;
+        word-break: break-word;
+        margin: 0;
+      }
+      .muted {
+        color: #6e6256;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>Symphony Dashboard</h1>
+      <p class="muted">Generated at ${escapeHtml(snapshot.generated_at)}</p>
+
+      <div class="grid">
+        <div class="card">
+          <div class="muted">Running</div>
+          <div class="metric">${snapshot.counts.running}</div>
+        </div>
+        <div class="card">
+          <div class="muted">Retrying</div>
+          <div class="metric">${snapshot.counts.retrying}</div>
+        </div>
+        <div class="card">
+          <div class="muted">Input Tokens</div>
+          <div class="metric">${snapshot.codex_totals.input_tokens}</div>
+        </div>
+        <div class="card">
+          <div class="muted">Output Tokens</div>
+          <div class="metric">${snapshot.codex_totals.output_tokens}</div>
+        </div>
+        <div class="card">
+          <div class="muted">Total Tokens</div>
+          <div class="metric">${snapshot.codex_totals.total_tokens}</div>
+        </div>
+        <div class="card">
+          <div class="muted">Seconds Running</div>
+          <div class="metric">${snapshot.codex_totals.seconds_running.toFixed(1)}</div>
+        </div>
+      </div>
+
+      <section>
+        <h2>Running Sessions</h2>
+        <table>
+          <thead>
+            <tr>
+              <th>Issue</th>
+              <th>State</th>
+              <th>Session</th>
+              <th>Turns</th>
+              <th>Last Event</th>
+              <th>Last Message</th>
+              <th>Last Event At</th>
+            </tr>
+          </thead>
+          <tbody>${runningRows}</tbody>
+        </table>
+      </section>
+
+      <section>
+        <h2>Retry Queue</h2>
+        <table>
+          <thead>
+            <tr>
+              <th>Issue</th>
+              <th>Attempt</th>
+              <th>Due At</th>
+              <th>Error</th>
+            </tr>
+          </thead>
+          <tbody>${retryRows}</tbody>
+        </table>
+      </section>
+
+      <section>
+        <h2>Rate Limits</h2>
+        <pre>${escapeHtml(JSON.stringify(snapshot.rate_limits, null, 2) ?? "null")}</pre>
+      </section>
+    </main>
+  </body>
+</html>`;
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}
+
+function toErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  return String(error);
+}

--- a/tests/observability/dashboard-server.test.ts
+++ b/tests/observability/dashboard-server.test.ts
@@ -1,0 +1,335 @@
+import { request as httpRequest } from "node:http";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import type { RuntimeSnapshot } from "../../src/logging/runtime-snapshot.js";
+import {
+  type DashboardServerHost,
+  type IssueDetailResponse,
+  type RefreshResponse,
+  createDashboardServer,
+  startDashboardServer,
+} from "../../src/observability/dashboard-server.js";
+
+describe("dashboard server", () => {
+  const servers: Array<{ close: () => Promise<void> }> = [];
+
+  afterEach(async () => {
+    await Promise.all(servers.splice(0).map((server) => server.close()));
+  });
+
+  it("serves the html dashboard and json state snapshot", async () => {
+    const server = await startDashboardServer({
+      port: 0,
+      host: createHost(),
+    });
+    servers.push(server);
+
+    const dashboard = await sendRequest(server.port, {
+      method: "GET",
+      path: "/",
+    });
+    expect(dashboard.statusCode).toBe(200);
+    expect(dashboard.headers["content-type"]).toContain("text/html");
+    expect(dashboard.body).toContain("Symphony Dashboard");
+    expect(dashboard.body).toContain("ABC-123");
+
+    const state = await sendRequest(server.port, {
+      method: "GET",
+      path: "/api/v1/state",
+    });
+    expect(state.statusCode).toBe(200);
+    expect(state.headers["content-type"]).toContain("application/json");
+    expect(JSON.parse(state.body)).toMatchObject({
+      counts: {
+        running: 1,
+        retrying: 1,
+      },
+      running: [{ issue_identifier: "ABC-123" }],
+    });
+  });
+
+  it("returns issue details and a 404 json error for unknown issues", async () => {
+    const server = await startDashboardServer({
+      port: 0,
+      host: createHost(),
+    });
+    servers.push(server);
+
+    const issue = await sendRequest(server.port, {
+      method: "GET",
+      path: "/api/v1/ABC-123",
+    });
+    expect(issue.statusCode).toBe(200);
+    expect(JSON.parse(issue.body)).toMatchObject({
+      issue_identifier: "ABC-123",
+      status: "running",
+      workspace: {
+        path: "/tmp/symphony/ABC-123",
+      },
+    });
+
+    const missing = await sendRequest(server.port, {
+      method: "GET",
+      path: "/api/v1/UNKNOWN-1",
+    });
+    expect(missing.statusCode).toBe(404);
+    expect(JSON.parse(missing.body)).toEqual({
+      error: {
+        code: "issue_not_found",
+        message:
+          "Issue 'UNKNOWN-1' is not tracked in the current runtime state.",
+      },
+    });
+  });
+
+  it("accepts refresh requests and rejects unsupported methods with 405", async () => {
+    const refreshCalls: RefreshResponse[] = [];
+    const server = await startDashboardServer({
+      port: 0,
+      host: createHost({
+        requestRefresh: () => {
+          const response = {
+            queued: true,
+            coalesced: false,
+            requested_at: "2026-03-06T12:00:00.000Z",
+            operations: ["poll", "reconcile"],
+          } satisfies RefreshResponse;
+          refreshCalls.push(response);
+          return response;
+        },
+      }),
+    });
+    servers.push(server);
+
+    const refresh = await sendRequest(server.port, {
+      method: "POST",
+      path: "/api/v1/refresh",
+      body: "{}",
+      headers: {
+        "content-type": "application/json",
+      },
+    });
+    expect(refresh.statusCode).toBe(202);
+    expect(JSON.parse(refresh.body)).toEqual({
+      queued: true,
+      coalesced: false,
+      requested_at: "2026-03-06T12:00:00.000Z",
+      operations: ["poll", "reconcile"],
+    });
+    expect(refreshCalls).toHaveLength(1);
+
+    const invalidMethod = await sendRequest(server.port, {
+      method: "POST",
+      path: "/api/v1/state",
+    });
+    expect(invalidMethod.statusCode).toBe(405);
+    expect(invalidMethod.headers.allow).toBe("GET");
+    expect(JSON.parse(invalidMethod.body)).toEqual({
+      error: {
+        code: "method_not_allowed",
+        message: "Method not allowed.",
+      },
+    });
+  });
+
+  it("returns snapshot_unavailable when the host snapshot fails", async () => {
+    const server = createDashboardServer({
+      host: createHost({
+        getRuntimeSnapshot: () => {
+          throw new Error("snapshot exploded");
+        },
+      }),
+    });
+    await new Promise<void>((resolve) =>
+      server.listen(0, "127.0.0.1", resolve),
+    );
+    const address = server.address();
+    if (address === null || typeof address === "string") {
+      throw new Error("expected TCP server address");
+    }
+    servers.push({
+      close: async () => {
+        await new Promise<void>((resolve, reject) => {
+          server.close((error) => {
+            if (error) {
+              reject(error);
+              return;
+            }
+            resolve();
+          });
+        });
+      },
+    });
+
+    const response = await sendRequest(address.port, {
+      method: "GET",
+      path: "/api/v1/state",
+    });
+    expect(response.statusCode).toBe(500);
+    expect(JSON.parse(response.body)).toEqual({
+      error: {
+        code: "snapshot_unavailable",
+        message: "snapshot exploded",
+      },
+    });
+  });
+});
+
+function createHost(
+  overrides?: Partial<DashboardServerHost>,
+): DashboardServerHost {
+  const snapshot = createSnapshot();
+  const issue = createIssueDetail();
+  return {
+    getRuntimeSnapshot: () => snapshot,
+    getIssueDetails: (issueIdentifier) =>
+      issueIdentifier === issue.issue_identifier ? issue : null,
+    requestRefresh: () => ({
+      queued: true,
+      coalesced: false,
+      requested_at: "2026-03-06T11:00:00.000Z",
+      operations: ["poll", "reconcile"],
+    }),
+    ...overrides,
+  };
+}
+
+function createSnapshot(): RuntimeSnapshot {
+  return {
+    generated_at: "2026-03-06T10:00:00.000Z",
+    counts: {
+      running: 1,
+      retrying: 1,
+    },
+    running: [
+      {
+        issue_id: "issue-1",
+        issue_identifier: "ABC-123",
+        state: "In Progress",
+        session_id: "thread-1-turn-3",
+        turn_count: 3,
+        last_event: "notification",
+        last_message: "Working on tests",
+        started_at: "2026-03-06T09:58:00.000Z",
+        last_event_at: "2026-03-06T09:59:30.000Z",
+        tokens: {
+          input_tokens: 1200,
+          output_tokens: 800,
+          total_tokens: 2000,
+        },
+      },
+    ],
+    retrying: [
+      {
+        issue_id: "issue-2",
+        issue_identifier: "ABC-124",
+        attempt: 2,
+        due_at: "2026-03-06T10:01:00.000Z",
+        error: "no available orchestrator slots",
+      },
+    ],
+    codex_totals: {
+      input_tokens: 1200,
+      output_tokens: 800,
+      total_tokens: 2000,
+      seconds_running: 153.2,
+    },
+    rate_limits: {
+      requestsRemaining: 7,
+    },
+  };
+}
+
+function createIssueDetail(): IssueDetailResponse {
+  return {
+    issue_identifier: "ABC-123",
+    issue_id: "issue-1",
+    status: "running",
+    workspace: {
+      path: "/tmp/symphony/ABC-123",
+    },
+    attempts: {
+      restart_count: 1,
+      current_retry_attempt: null,
+    },
+    running: {
+      session_id: "thread-1-turn-3",
+      turn_count: 3,
+      state: "In Progress",
+      started_at: "2026-03-06T09:58:00.000Z",
+      last_event: "notification",
+      last_message: "Working on tests",
+      last_event_at: "2026-03-06T09:59:30.000Z",
+      tokens: {
+        input_tokens: 1200,
+        output_tokens: 800,
+        total_tokens: 2000,
+      },
+    },
+    retry: null,
+    logs: {
+      codex_session_logs: [
+        {
+          label: "latest",
+          path: "/var/log/symphony/ABC-123/latest.log",
+          url: null,
+        },
+      ],
+    },
+    recent_events: [
+      {
+        at: "2026-03-06T09:59:30.000Z",
+        event: "notification",
+        message: "Working on tests",
+      },
+    ],
+    last_error: null,
+    tracked: {},
+  };
+}
+
+function sendRequest(
+  port: number,
+  input: {
+    method: string;
+    path: string;
+    body?: string;
+    headers?: Record<string, string>;
+  },
+): Promise<{
+  statusCode: number;
+  headers: Record<string, string | string[] | undefined>;
+  body: string;
+}> {
+  return new Promise((resolve, reject) => {
+    const request = httpRequest(
+      {
+        host: "127.0.0.1",
+        port,
+        method: input.method,
+        path: input.path,
+        headers: input.headers,
+      },
+      (response) => {
+        const chunks: Buffer[] = [];
+        response.on("data", (chunk) => {
+          chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+        });
+        response.on("end", () => {
+          resolve({
+            statusCode: response.statusCode ?? 0,
+            headers: response.headers,
+            body: Buffer.concat(chunks).toString("utf8"),
+          });
+        });
+      },
+    );
+
+    request.on("error", reject);
+    if (input.body !== undefined) {
+      request.write(input.body);
+    }
+    request.end();
+  });
+}


### PR DESCRIPTION
## Problem
Task 15 requires the optional HTTP observability surface from `SPEC.upstream.md` section 13.7: a human-readable dashboard plus the baseline `/api/v1/*` endpoints.

## Scope
- add an HTTP dashboard server module with loopback-oriented startup helpers
- implement `/`, `GET /api/v1/state`, `GET /api/v1/:issue_identifier`, and `POST /api/v1/refresh`
- return JSON error envelopes for issue-not-found and method-not-allowed cases
- export the new observability module from the package entrypoint

## References
- `SPEC.upstream.md` section 13.7
- `IMPLEMENTATION_PLAN.md` task 15

## Test Evidence
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
