### PR TITLE
Integrate orchestrator and agent runtime

### DIFF
--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -70,6 +70,7 @@ export interface AgentRunnerOptions {
 export interface AgentRunInput {
   issue: Issue;
   attempt: number | null;
+  signal?: AbortSignal;
 }
 
 export interface AgentRunResult {
@@ -167,8 +168,16 @@ export class AgentRunner {
       startedAt: new Date().toISOString(),
       status: "preparing_workspace",
     };
+    const abortController = createAgentAbortController(input.signal);
 
     try {
+      abortController.throwIfAborted({
+        issue,
+        workspace,
+        runAttempt,
+        liveSession,
+      });
+
       workspace = await this.workspaceManager.createForIssue(issue.identifier);
       runAttempt.workspacePath = validateWorkspaceCwd({
         cwd: workspace.path,
@@ -206,12 +215,19 @@ export class AgentRunner {
           });
         },
       });
+      abortController.bindClient(client);
 
       for (
         let turnNumber = 1;
         turnNumber <= this.config.agent.maxTurns;
         turnNumber += 1
       ) {
+        abortController.throwIfAborted({
+          issue,
+          workspace,
+          runAttempt,
+          liveSession,
+        });
         runAttempt.status = "building_prompt";
         const prompt = await buildTurnPrompt({
           workflow: {
@@ -276,11 +292,14 @@ export class AgentRunner {
         workspace,
         runAttempt,
         liveSession,
+        ...(input.signal === undefined ? {} : { signal: input.signal }),
       });
       runAttempt.status = wrapped.status;
       runAttempt.error = wrapped.message;
       throw wrapped;
     } finally {
+      abortController.dispose();
+
       if (client !== null) {
         await closeBestEffort(client);
       }
@@ -339,9 +358,23 @@ export class AgentRunner {
     workspace: Workspace | null;
     runAttempt: RunAttempt;
     liveSession: LiveSession;
+    signal?: AbortSignal;
   }): AgentRunnerError {
     if (input.error instanceof AgentRunnerError) {
       return input.error;
+    }
+
+    if (input.signal?.aborted) {
+      return new AgentRunnerError({
+        message: toAbortMessage(input.signal.reason),
+        status: "canceled_by_reconciliation",
+        failedPhase: input.runAttempt.status,
+        issue: input.issue,
+        workspace: input.workspace,
+        runAttempt: { ...input.runAttempt },
+        liveSession: { ...input.liveSession },
+        cause: input.error,
+      });
     }
 
     const message =
@@ -411,6 +444,84 @@ function cloneIssue(issue: Issue): Issue {
     labels: [...issue.labels],
     blockedBy: issue.blockedBy.map((blocker) => ({ ...blocker })),
   };
+}
+
+function createAgentAbortController(signal: AbortSignal | undefined): {
+  bindClient(client: AgentRunnerCodexClient): void;
+  dispose(): void;
+  throwIfAborted(input: {
+    issue: Issue;
+    workspace: Workspace | null;
+    runAttempt: RunAttempt;
+    liveSession: LiveSession;
+  }): void;
+} {
+  let client: AgentRunnerCodexClient | null = null;
+  let listener: (() => void) | null = null;
+
+  const closeClient = () => {
+    if (client === null) {
+      return;
+    }
+
+    void closeBestEffort(client);
+  };
+
+  if (signal !== undefined) {
+    listener = () => {
+      closeClient();
+    };
+    signal.addEventListener("abort", listener, { once: true });
+  }
+
+  return {
+    bindClient(nextClient) {
+      client = nextClient;
+      if (signal?.aborted) {
+        closeClient();
+      }
+    },
+    dispose() {
+      if (signal !== undefined && listener !== null) {
+        signal.removeEventListener("abort", listener);
+      }
+      listener = null;
+      client = null;
+    },
+    throwIfAborted(input) {
+      if (!signal?.aborted) {
+        return;
+      }
+
+      throw new AgentRunnerError({
+        message: toAbortMessage(signal.reason),
+        status: "canceled_by_reconciliation",
+        failedPhase: input.runAttempt.status,
+        issue: input.issue,
+        workspace: input.workspace,
+        runAttempt: { ...input.runAttempt },
+        liveSession: { ...input.liveSession },
+      });
+    },
+  };
+}
+
+function toAbortMessage(reason: unknown): string {
+  if (typeof reason === "string" && reason.trim().length > 0) {
+    return reason.trim();
+  }
+
+  if (
+    typeof reason === "object" &&
+    reason !== null &&
+    "message" in reason &&
+    typeof reason.message === "string" &&
+    reason.message.trim().length > 0
+  ) {
+    return reason.message.trim();
+  }
+
+  return "Agent run cancelled.";
 }
 
 export type { BuildTurnPromptInput };

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ export * from "./logging/session-metrics.js";
 export * from "./logging/structured-logger.js";
 export * from "./observability/dashboard-server.js";
 export * from "./orchestrator/core.js";
+export * from "./orchestrator/runtime-host.js";
 export * from "./workspace/hooks.js";
 export * from "./tracker/errors.js";
 export * from "./tracker/linear-client.js";

--- a/src/orchestrator/core.ts
+++ b/src/orchestrator/core.ts
@@ -1,3 +1,4 @@
+import type { CodexClientEvent } from "../codex/app-server-client.js";
 import { validateDispatchConfig } from "../config/config-resolver.js";
 import type {
   DispatchValidationResult,
@@ -12,7 +13,10 @@ import {
   createInitialOrchestratorState,
   normalizeIssueState,
 } from "../domain/model.js";
-import { addEndedSessionRuntime } from "../logging/session-metrics.js";
+import {
+  addEndedSessionRuntime,
+  applyCodexEventToOrchestratorState,
+} from "../logging/session-metrics.js";
 import type { IssueStateSnapshot, IssueTracker } from "../tracker/tracker.js";
 
 const CONTINUATION_RETRY_DELAY_MS = 1_000;
@@ -46,6 +50,10 @@ export interface RetryTimerResult {
   dispatched: boolean;
   released: boolean;
   retryEntry: RetryEntry | null;
+}
+
+export interface CodexEventResult {
+  applied: boolean;
 }
 
 export interface TimerScheduler {
@@ -323,6 +331,19 @@ export class OrchestratorCore {
         delayType: "failure",
       },
     );
+  }
+
+  onCodexEvent(input: {
+    issueId: string;
+    event: CodexClientEvent;
+  }): CodexEventResult {
+    const runningEntry = this.state.running[input.issueId];
+    if (runningEntry === undefined) {
+      return { applied: false };
+    }
+
+    applyCodexEventToOrchestratorState(this.state, runningEntry, input.event);
+    return { applied: true };
   }
 
   private syncStateFromConfig(): void {

--- a/src/orchestrator/runtime-host.ts
+++ b/src/orchestrator/runtime-host.ts
@@ -1,0 +1,389 @@
+import type { AgentRunResult, AgentRunnerEvent } from "../agent/runner.js";
+import { AgentRunner } from "../agent/runner.js";
+import type { ResolvedWorkflowConfig } from "../config/types.js";
+import type { Issue, RetryEntry, RunningEntry } from "../domain/model.js";
+import {
+  type RuntimeSnapshot,
+  buildRuntimeSnapshot,
+} from "../logging/runtime-snapshot.js";
+import type {
+  DashboardServerHost,
+  IssueDetailResponse,
+  RefreshResponse,
+} from "../observability/dashboard-server.js";
+import type { IssueTracker } from "../tracker/tracker.js";
+import { WorkspaceManager } from "../workspace/workspace-manager.js";
+import type {
+  OrchestratorCoreOptions,
+  StopReason,
+  StopRequest,
+  TimerScheduler,
+} from "./core.js";
+import { OrchestratorCore } from "./core.js";
+
+export interface AgentRunnerLike {
+  run(input: {
+    issue: Issue;
+    attempt: number | null;
+    signal?: AbortSignal;
+  }): Promise<AgentRunResult>;
+}
+
+export interface RuntimeHostOptions {
+  config: ResolvedWorkflowConfig;
+  tracker: IssueTracker;
+  agentRunner?: AgentRunnerLike;
+  createAgentRunner?: (input: {
+    onEvent: (event: AgentRunnerEvent) => void;
+  }) => AgentRunnerLike;
+  workspaceManager?: WorkspaceManager;
+  now?: () => Date;
+}
+
+interface WorkerExecution {
+  issueId: string;
+  issueIdentifier: string;
+  controller: AbortController;
+  completion: Promise<void>;
+  stopRequest: StopRequest | null;
+  lastResult: AgentRunResult | null;
+}
+
+export class OrchestratorRuntimeHost implements DashboardServerHost {
+  private readonly config: ResolvedWorkflowConfig;
+
+  private readonly tracker: IssueTracker;
+
+  private readonly workspaceManager: WorkspaceManager;
+
+  private readonly agentRunner: AgentRunnerLike;
+
+  private readonly now: () => Date;
+
+  private readonly workers = new Map<string, WorkerExecution>();
+
+  private readonly orchestrator: OrchestratorCore;
+
+  private eventQueue: Promise<unknown> = Promise.resolve();
+
+  private refreshQueued = false;
+
+  constructor(options: RuntimeHostOptions) {
+    this.config = options.config;
+    this.tracker = options.tracker;
+    this.now = options.now ?? (() => new Date());
+    this.workspaceManager =
+      options.workspaceManager ??
+      new WorkspaceManager({
+        root: options.config.workspace.root,
+      });
+    this.agentRunner =
+      options.agentRunner ??
+      options.createAgentRunner?.({
+        onEvent: (event) => {
+          void this.enqueue(async () => {
+            this.orchestrator.onCodexEvent({
+              issueId: event.issueId,
+              event,
+            });
+          });
+        },
+      }) ??
+      new AgentRunner({
+        config: options.config,
+        tracker: options.tracker,
+        workspaceManager: this.workspaceManager,
+        onEvent: (event) => {
+          void this.enqueue(async () => {
+            this.orchestrator.onCodexEvent({
+              issueId: event.issueId,
+              event,
+            });
+          });
+        },
+      });
+
+    const timerScheduler = createQueuedTimerScheduler({
+      run: (callback) => {
+        void this.enqueue(async () => {
+          callback();
+        });
+      },
+    });
+
+    const orchestratorOptions: OrchestratorCoreOptions = {
+      config: options.config,
+      tracker: options.tracker,
+      now: this.now,
+      timerScheduler,
+      spawnWorker: async ({ issue, attempt }) =>
+        this.spawnWorkerExecution(issue, attempt),
+      stopRunningIssue: async (input) => {
+        await this.stopWorkerExecution(input.issueId, {
+          issueId: input.issueId,
+          issueIdentifier: input.runningEntry.identifier,
+          cleanupWorkspace: input.cleanupWorkspace,
+          reason: input.reason,
+        });
+      },
+    };
+
+    this.orchestrator = new OrchestratorCore(orchestratorOptions);
+  }
+
+  getState() {
+    return this.orchestrator.getState();
+  }
+
+  async pollOnce() {
+    return this.enqueue(async () => this.orchestrator.pollTick());
+  }
+
+  async runRetryTimer(issueId: string) {
+    return this.enqueue(async () => this.orchestrator.onRetryTimer(issueId));
+  }
+
+  async flushEvents(): Promise<void> {
+    await this.eventQueue;
+  }
+
+  async waitForIdle(): Promise<void> {
+    await this.eventQueue;
+    await Promise.allSettled(
+      [...this.workers.values()].map((worker) => worker.completion),
+    );
+    await this.eventQueue;
+  }
+
+  async getRuntimeSnapshot(): Promise<RuntimeSnapshot> {
+    return buildRuntimeSnapshot(this.orchestrator.getState(), {
+      now: this.now(),
+    });
+  }
+
+  async getIssueDetails(
+    issueIdentifier: string,
+  ): Promise<IssueDetailResponse | null> {
+    const running = Object.values(this.orchestrator.getState().running).find(
+      (entry) => entry.identifier === issueIdentifier,
+    );
+    if (running !== undefined) {
+      return toRunningIssueDetail(running);
+    }
+
+    const retry = Object.values(
+      this.orchestrator.getState().retryAttempts,
+    ).find((entry) => entry.identifier === issueIdentifier);
+    if (retry !== undefined) {
+      return toRetryIssueDetail(issueIdentifier, retry);
+    }
+
+    return null;
+  }
+
+  async requestRefresh(): Promise<RefreshResponse> {
+    const requestedAt = this.now().toISOString();
+    const coalesced = this.refreshQueued;
+    this.refreshQueued = true;
+
+    if (!coalesced) {
+      void this.enqueue(async () => {
+        this.refreshQueued = false;
+        await this.orchestrator.pollTick();
+      });
+    }
+
+    return {
+      queued: true,
+      coalesced,
+      requested_at: requestedAt,
+      operations: ["poll", "reconcile"],
+    };
+  }
+
+  private async spawnWorkerExecution(
+    issue: Issue,
+    attempt: number | null,
+  ): Promise<{
+    workerHandle: WorkerExecution;
+    monitorHandle: Promise<void>;
+  }> {
+    const controller = new AbortController();
+    const execution: WorkerExecution = {
+      issueId: issue.id,
+      issueIdentifier: issue.identifier,
+      controller,
+      stopRequest: null,
+      lastResult: null,
+      completion: Promise.resolve(),
+    };
+
+    const completion = this.agentRunner
+      .run({
+        issue,
+        attempt,
+        signal: controller.signal,
+      })
+      .then(async (result) => {
+        execution.lastResult = result;
+        await this.enqueue(async () => {
+          await this.finalizeWorkerExecution(execution, {
+            outcome: "normal",
+            endedAt: this.now(),
+          });
+        });
+      })
+      .catch(async (error) => {
+        await this.enqueue(async () => {
+          await this.finalizeWorkerExecution(execution, {
+            outcome: "abnormal",
+            reason:
+              execution.stopRequest === null
+                ? toErrorMessage(error)
+                : `stopped after ${execution.stopRequest.reason}`,
+          });
+        });
+      });
+
+    execution.completion = completion;
+    this.workers.set(issue.id, execution);
+
+    return {
+      workerHandle: execution,
+      monitorHandle: completion,
+    };
+  }
+
+  private async stopWorkerExecution(
+    issueId: string,
+    input: StopRequest,
+  ): Promise<void> {
+    const execution = this.workers.get(issueId);
+    if (execution === undefined) {
+      return;
+    }
+
+    execution.stopRequest = input;
+    execution.controller.abort(`Stopped due to ${input.reason}.`);
+  }
+
+  private async finalizeWorkerExecution(
+    execution: WorkerExecution,
+    input: {
+      outcome: "normal" | "abnormal";
+      reason?: string;
+      endedAt?: Date;
+    },
+  ): Promise<void> {
+    this.workers.delete(execution.issueId);
+
+    if (execution.stopRequest?.cleanupWorkspace === true) {
+      await this.workspaceManager.removeForIssue(execution.issueIdentifier);
+    }
+
+    this.orchestrator.onWorkerExit({
+      issueId: execution.issueId,
+      outcome: input.outcome,
+      ...(input.reason === undefined ? {} : { reason: input.reason }),
+      endedAt: input.endedAt ?? this.now(),
+    });
+  }
+
+  private enqueue<T>(task: () => Promise<T> | T): Promise<T> {
+    const next = this.eventQueue.then(task, task);
+    this.eventQueue = next.then(
+      () => undefined,
+      () => undefined,
+    );
+    return next;
+  }
+}
+
+function createQueuedTimerScheduler(input: {
+  run: (callback: () => void) => void;
+}): TimerScheduler {
+  return {
+    set(callback, delayMs) {
+      return setTimeout(() => {
+        input.run(callback);
+      }, delayMs);
+    },
+    clear(handle) {
+      if (handle !== null) {
+        clearTimeout(handle);
+      }
+    },
+  };
+}
+
+function toRunningIssueDetail(running: RunningEntry): IssueDetailResponse {
+  return {
+    issue_identifier: running.identifier,
+    issue_id: running.issue.id,
+    status: "running",
+    workspace: {
+      path: "",
+    },
+    attempts: {
+      restart_count: running.retryAttempt ?? 0,
+      current_retry_attempt: running.retryAttempt,
+    },
+    running: {
+      session_id: running.sessionId,
+      turn_count: running.turnCount,
+      state: running.issue.state,
+      started_at: running.startedAt,
+      last_event: running.lastCodexEvent,
+      last_message: running.lastCodexMessage,
+      last_event_at: running.lastCodexTimestamp,
+      tokens: {
+        input_tokens: running.codexInputTokens,
+        output_tokens: running.codexOutputTokens,
+        total_tokens: running.codexTotalTokens,
+      },
+    },
+    retry: null,
+    logs: {
+      codex_session_logs: [],
+    },
+    recent_events: [],
+    last_error: null,
+    tracked: {},
+  };
+}
+
+function toRetryIssueDetail(
+  issueIdentifier: string,
+  retry: RetryEntry,
+): IssueDetailResponse {
+  return {
+    issue_identifier: issueIdentifier,
+    issue_id: retry.issueId,
+    status: "retry_queued",
+    workspace: null,
+    attempts: {
+      restart_count: retry.attempt,
+      current_retry_attempt: retry.attempt,
+    },
+    running: null,
+    retry: {
+      attempt: retry.attempt,
+      due_at: new Date(retry.dueAtMs).toISOString(),
+      error: retry.error,
+    },
+    logs: {
+      codex_session_logs: [],
+    },
+    recent_events: [],
+    last_error: retry.error,
+    tracked: {},
+  };
+}
+
+function toErrorMessage(error: unknown): string {
+  if (error instanceof Error && error.message.trim().length > 0) {
+    return error.message;
+  }
+
+  return "worker failed";
+}

--- a/tests/agent/runner.test.ts
+++ b/tests/agent/runner.test.ts
@@ -212,6 +212,55 @@ describe("AgentRunner", () => {
       workspacePath: expect.stringContaining("ABC-123"),
     });
   });
+
+  it("cancels the active run when aborted externally", async () => {
+    const root = await createRoot();
+    const close = vi.fn().mockResolvedValue(undefined);
+    const controller = new AbortController();
+    const runner = new AgentRunner({
+      config: createConfig(root, "unused"),
+      tracker: createTracker(),
+      createCodexClient: (input) => ({
+        async startSession({ prompt, title }) {
+          return await new Promise((resolve, reject) => {
+            input.onEvent({
+              event: "session_started",
+              timestamp: new Date("2026-03-06T00:00:00.000Z").toISOString(),
+              codexAppServerPid: "1001",
+              sessionId: "thread-1-turn-1",
+              threadId: "thread-1",
+              turnId: "turn-1",
+            });
+            controller.signal.addEventListener(
+              "abort",
+              () => {
+                reject(new Error("Stopped due to terminal_state."));
+              },
+              { once: true },
+            );
+          });
+        },
+        async continueTurn() {
+          throw new Error("unexpected continuation turn");
+        },
+        close,
+      }),
+    });
+
+    const pending = runner.run({
+      issue: ISSUE_FIXTURE,
+      attempt: null,
+      signal: controller.signal,
+    });
+    controller.abort("Stopped due to terminal_state.");
+
+    await expect(pending).rejects.toMatchObject({
+      name: "AgentRunnerError",
+      status: "canceled_by_reconciliation",
+      message: "Stopped due to terminal_state.",
+    } satisfies Partial<AgentRunnerError>);
+    expect(close).toHaveBeenCalled();
+  });
 });
 
 function createStubCodexClient(

--- a/tests/orchestrator/core.test.ts
+++ b/tests/orchestrator/core.test.ts
@@ -201,6 +201,46 @@ describe("orchestrator core", () => {
     expect(computeFailureRetryDelayMs(3, 30_000)).toBe(30_000);
   });
 
+  it("applies codex session events to the running entry and aggregate counters", async () => {
+    const orchestrator = createOrchestrator();
+
+    await orchestrator.pollTick();
+    const result = orchestrator.onCodexEvent({
+      issueId: "1",
+      event: {
+        event: "turn_completed",
+        timestamp: "2026-03-06T00:00:04.000Z",
+        codexAppServerPid: "1001",
+        sessionId: "thread-1-turn-1",
+        threadId: "thread-1",
+        turnId: "turn-1",
+        usage: {
+          inputTokens: 13,
+          outputTokens: 8,
+          totalTokens: 21,
+        },
+        rateLimits: {
+          requestsRemaining: 9,
+        },
+        message: "turn completed",
+      },
+    });
+
+    expect(result).toEqual({ applied: true });
+    expect(orchestrator.getState().running["1"]).toMatchObject({
+      sessionId: "thread-1-turn-1",
+      threadId: "thread-1",
+      turnId: "turn-1",
+      lastCodexEvent: "turn_completed",
+      lastCodexMessage: "turn completed",
+      codexTotalTokens: 21,
+    });
+    expect(orchestrator.getState().codexTotals.totalTokens).toBe(21);
+    expect(orchestrator.getState().codexRateLimits).toEqual({
+      requestsRemaining: 9,
+    });
+  });
+
   it("requeues retry timers when slots are exhausted", async () => {
     const timers = createFakeTimerScheduler();
     const tracker = createTracker({

--- a/tests/orchestrator/runtime-host.test.ts
+++ b/tests/orchestrator/runtime-host.test.ts
@@ -1,0 +1,347 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type {
+  AgentRunResult,
+  AgentRunnerEvent,
+} from "../../src/agent/runner.js";
+import type { ResolvedWorkflowConfig } from "../../src/config/types.js";
+import type { Issue } from "../../src/domain/model.js";
+import { OrchestratorRuntimeHost } from "../../src/orchestrator/runtime-host.js";
+import type {
+  IssueStateSnapshot,
+  IssueTracker,
+} from "../../src/tracker/tracker.js";
+
+describe("OrchestratorRuntimeHost", () => {
+  it("feeds codex events into orchestrator state and schedules continuation retry after a normal worker exit", async () => {
+    const tracker = createTracker();
+    const fakeRunner = new FakeAgentRunner();
+    const host = new OrchestratorRuntimeHost({
+      config: createConfig(),
+      tracker,
+      createAgentRunner: ({ onEvent }) => {
+        fakeRunner.onEvent = onEvent;
+        return fakeRunner;
+      },
+      now: () => new Date("2026-03-06T00:00:05.000Z"),
+    });
+
+    const tick = await host.pollOnce();
+
+    expect(tick.dispatchedIssueIds).toEqual(["1"]);
+    fakeRunner.emit("1", {
+      event: "session_started",
+      timestamp: "2026-03-06T00:00:01.000Z",
+      codexAppServerPid: "1001",
+      sessionId: "thread-1-turn-1",
+      threadId: "thread-1",
+      turnId: "turn-1",
+    });
+    fakeRunner.emit("1", {
+      event: "turn_completed",
+      timestamp: "2026-03-06T00:00:02.000Z",
+      codexAppServerPid: "1001",
+      sessionId: "thread-1-turn-1",
+      threadId: "thread-1",
+      turnId: "turn-1",
+      usage: {
+        inputTokens: 11,
+        outputTokens: 7,
+        totalTokens: 18,
+      },
+      rateLimits: {
+        requestsRemaining: 9,
+      },
+      message: "turn completed",
+    });
+    await host.flushEvents();
+
+    let snapshot = await host.getRuntimeSnapshot();
+    expect(snapshot.running).toEqual([
+      expect.objectContaining({
+        issue_id: "1",
+        session_id: "thread-1-turn-1",
+        turn_count: 1,
+        last_event: "turn_completed",
+        last_message: "turn completed",
+        tokens: {
+          input_tokens: 11,
+          output_tokens: 7,
+          total_tokens: 18,
+        },
+      }),
+    ]);
+    expect(snapshot.codex_totals.total_tokens).toBe(18);
+
+    fakeRunner.resolve("1", {
+      issue: createIssue({ state: "In Progress" }),
+      workspace: {
+        path: "/tmp/workspaces/ISSUE-1",
+        workspaceKey: "ISSUE-1",
+        createdNow: true,
+      },
+      runAttempt: {
+        issueId: "1",
+        issueIdentifier: "ISSUE-1",
+        attempt: null,
+        workspacePath: "/tmp/workspaces/ISSUE-1",
+        startedAt: "2026-03-06T00:00:00.000Z",
+        status: "succeeded",
+      },
+      liveSession: {
+        sessionId: "thread-1-turn-1",
+        threadId: "thread-1",
+        turnId: "turn-1",
+        codexAppServerPid: "1001",
+        lastCodexEvent: "turn_completed",
+        lastCodexTimestamp: "2026-03-06T00:00:02.000Z",
+        lastCodexMessage: "turn completed",
+        codexInputTokens: 11,
+        codexOutputTokens: 7,
+        codexTotalTokens: 18,
+        lastReportedInputTokens: 11,
+        lastReportedOutputTokens: 7,
+        lastReportedTotalTokens: 18,
+        turnCount: 1,
+      },
+      turnsCompleted: 1,
+      lastTurn: null,
+      rateLimits: {
+        requestsRemaining: 9,
+      },
+    });
+    await host.waitForIdle();
+
+    snapshot = await host.getRuntimeSnapshot();
+    expect(snapshot.running).toEqual([]);
+    expect(snapshot.retrying).toEqual([
+      expect.objectContaining({
+        issue_id: "1",
+        issue_identifier: "ISSUE-1",
+        attempt: 1,
+        error: null,
+      }),
+    ]);
+  });
+
+  it("cancels a reconciled worker and releases the claim when the issue is no longer eligible on retry", async () => {
+    const tracker = createTracker();
+    const fakeRunner = new FakeAgentRunner();
+    const host = new OrchestratorRuntimeHost({
+      config: createConfig(),
+      tracker,
+      createAgentRunner: ({ onEvent }) => {
+        fakeRunner.onEvent = onEvent;
+        return fakeRunner;
+      },
+      now: () => new Date("2026-03-06T00:00:05.000Z"),
+    });
+
+    await host.pollOnce();
+    tracker.setStateSnapshots([
+      { id: "1", identifier: "ISSUE-1", state: "Done" },
+    ]);
+
+    const reconcileTick = await host.pollOnce();
+    expect(reconcileTick.stopRequests).toEqual([
+      {
+        issueId: "1",
+        issueIdentifier: "ISSUE-1",
+        cleanupWorkspace: true,
+        reason: "terminal_state",
+      },
+    ]);
+    await host.waitForIdle();
+
+    expect(fakeRunner.abortReasons).toEqual(["Stopped due to terminal_state."]);
+    expect(Object.keys(host.getState().retryAttempts)).toEqual(["1"]);
+
+    tracker.setCandidates([]);
+    const retryResult = await host.runRetryTimer("1");
+
+    expect(retryResult).toEqual({
+      dispatched: false,
+      released: true,
+      retryEntry: null,
+    });
+    expect([...host.getState().claimed]).toEqual([]);
+  });
+
+  it("coalesces manual refresh requests onto a single queued poll", async () => {
+    const tracker = createTracker({
+      candidates: [],
+    });
+    const host = new OrchestratorRuntimeHost({
+      config: createConfig(),
+      tracker,
+      agentRunner: new FakeAgentRunner(),
+      now: () => new Date("2026-03-06T00:00:05.000Z"),
+    });
+
+    const [first, second] = await Promise.all([
+      host.requestRefresh(),
+      host.requestRefresh(),
+    ]);
+    await host.waitForIdle();
+
+    expect(first).toMatchObject({
+      queued: true,
+      coalesced: false,
+      operations: ["poll", "reconcile"],
+    });
+    expect(second).toMatchObject({
+      queued: true,
+      coalesced: true,
+    });
+    expect(tracker.fetchCandidateIssues).toHaveBeenCalledTimes(1);
+  });
+});
+
+class FakeAgentRunner {
+  onEvent: ((event: AgentRunnerEvent) => void) | undefined;
+  readonly runs = new Map<
+    string,
+    {
+      resolve: (result: AgentRunResult) => void;
+      reject: (error: Error) => void;
+    }
+  >();
+  readonly abortReasons: string[] = [];
+
+  async run(input: {
+    issue: Issue;
+    attempt: number | null;
+    signal?: AbortSignal;
+  }): Promise<AgentRunResult> {
+    return await new Promise<AgentRunResult>((resolve, reject) => {
+      this.runs.set(input.issue.id, { resolve, reject });
+      input.signal?.addEventListener(
+        "abort",
+        () => {
+          const reason =
+            typeof input.signal?.reason === "string"
+              ? input.signal.reason
+              : "aborted";
+          this.abortReasons.push(reason);
+          reject(new Error(reason));
+        },
+        { once: true },
+      );
+    });
+  }
+
+  emit(
+    issueId: string,
+    event: Omit<
+      AgentRunnerEvent,
+      "issueId" | "issueIdentifier" | "attempt" | "workspacePath" | "turnCount"
+    > &
+      Partial<Pick<AgentRunnerEvent, "turnCount">>,
+  ): void {
+    this.onEvent?.({
+      ...event,
+      issueId,
+      issueIdentifier: "ISSUE-1",
+      attempt: null,
+      workspacePath: "/tmp/workspaces/ISSUE-1",
+      turnCount: event.turnCount ?? 0,
+    });
+  }
+
+  resolve(issueId: string, result: AgentRunResult): void {
+    const run = this.runs.get(issueId);
+    if (run === undefined) {
+      throw new Error(`No fake run registered for ${issueId}.`);
+    }
+    this.runs.delete(issueId);
+    run.resolve(result);
+  }
+}
+
+function createTracker(input?: { candidates?: Issue[] }) {
+  let candidates = input?.candidates ?? [createIssue()];
+  let stateSnapshots: IssueStateSnapshot[] = [
+    { id: "1", identifier: "ISSUE-1", state: "In Progress" },
+  ];
+
+  const tracker: IssueTracker & {
+    setCandidates(next: Issue[]): void;
+    setStateSnapshots(next: IssueStateSnapshot[]): void;
+  } = {
+    fetchCandidateIssues: vi.fn(async () => candidates),
+    fetchIssuesByStates: vi.fn(async () => []),
+    fetchIssueStatesByIds: vi.fn(async () => stateSnapshots),
+    setCandidates(next) {
+      candidates = next;
+    },
+    setStateSnapshots(next) {
+      stateSnapshots = next;
+    },
+  };
+
+  return tracker;
+}
+
+function createIssue(overrides?: Partial<Issue>): Issue {
+  return {
+    id: "1",
+    identifier: "ISSUE-1",
+    title: "Issue 1",
+    description: null,
+    priority: 1,
+    state: "In Progress",
+    branchName: null,
+    url: null,
+    labels: [],
+    blockedBy: [],
+    createdAt: "2026-03-01T00:00:00.000Z",
+    updatedAt: "2026-03-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function createConfig(): ResolvedWorkflowConfig {
+  return {
+    workflowPath: "/tmp/WORKFLOW.md",
+    promptTemplate: "Prompt",
+    tracker: {
+      kind: "linear",
+      endpoint: "https://api.linear.app/graphql",
+      apiKey: "token",
+      projectSlug: "project",
+      activeStates: ["Todo", "In Progress", "In Review"],
+      terminalStates: ["Done", "Canceled"],
+    },
+    polling: {
+      intervalMs: 30_000,
+    },
+    workspace: {
+      root: "/tmp/workspaces",
+    },
+    hooks: {
+      afterCreate: null,
+      beforeRun: null,
+      afterRun: null,
+      beforeRemove: null,
+      timeoutMs: 30_000,
+    },
+    agent: {
+      maxConcurrentAgents: 2,
+      maxTurns: 5,
+      maxRetryBackoffMs: 300_000,
+      maxConcurrentAgentsByState: {},
+    },
+    codex: {
+      command: "codex-app-server",
+      approvalPolicy: "never",
+      threadSandbox: null,
+      turnSandboxPolicy: null,
+      turnTimeoutMs: 120_000,
+      readTimeoutMs: 5_000,
+      stallTimeoutMs: 60_000,
+    },
+    server: {
+      port: null,
+    },
+  };
+}


### PR DESCRIPTION
## Problem
Task 13 requires the runner/orchestrator boundary to behave like a real runtime instead of isolated module tests. The current code had `AgentRunner` and `OrchestratorCore`, but no host layer to serialize worker events, propagate Codex telemetry back into orchestrator state, or connect reconciliation-driven stops to worker cancellation and retry/release behavior.

## Scope
- add `OrchestratorRuntimeHost` to own the serialized event queue, worker lifecycle, manual refresh, retry timer execution, and dashboard host surface
- add `OrchestratorCore.onCodexEvent()` so Codex session events update running entries, token counters, and rate limits in the authoritative orchestrator state
- extend `AgentRunner` with external cancellation support so reconciliation and stall/terminal stops can abort live runs cleanly
- export the runtime host from the package entrypoint
- add task 13 focused tests for Codex event propagation, continuation retry scheduling, reconciliation-triggered cancellation/release, refresh coalescing, and runner abort behavior

## References
- Local plan: `IMPLEMENTATION_PLAN.md` task 13
- Upstream spec: `SPEC.upstream.md` sections 7, 8, 12, 16.3-16.6, 17.4

## Test Evidence
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`
