### PR TITLE
Add README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Symphony turns project work into isolated, autonomous implementation runs, so teams can manage work instead of supervising coding agents.**
 
-> Harness Engineering is exactly what I want.
+> Harness Engineering is exactly what I want!
 > Not vibe coding. Not just giving OpenClaw a sentence and asking it to orchestrate the rest.
 
 `symphony-ts` is a TypeScript implementation of the original


### PR DESCRIPTION
## Summary
- add a polished GitHub-facing README for project promotion
- reposition the repo around the completed Symphony product narrative
- align the messaging with the upstream Symphony model while keeping local repo references

## Testing
- not run for this docs-only change