### PR TITLE
Complete CLI runtime host

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "type": "module",
+  "bin": {
+    "symphony": "./dist/cli/main.js"
+  },
   "engines": {
     "node": ">=22.0.0",
     "pnpm": ">=10.0.0"

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -1,0 +1,276 @@
+#!/usr/bin/env node
+
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+import { resolveWorkflowConfig } from "../config/config-resolver.js";
+import { WORKFLOW_FILENAME } from "../config/defaults.js";
+import { loadWorkflowDefinition } from "../config/workflow-loader.js";
+import { ERROR_CODES } from "../errors/codes.js";
+import {
+  type RuntimeServiceHandle,
+  startRuntimeService,
+} from "../orchestrator/runtime-host.js";
+
+export const CLI_ACKNOWLEDGEMENT_FLAG = "--acknowledge-high-trust-preview";
+
+export interface CliOptions {
+  workflowPath: string | null;
+  logsRoot: string | null;
+  port: number | null;
+  acknowledged: boolean;
+  help: boolean;
+}
+
+export interface CliRuntimeSettings {
+  config: ReturnType<typeof resolveWorkflowConfig>;
+  logsRoot: string | null;
+}
+
+export interface CliHost {
+  waitForExit(): Promise<number | undefined>;
+  shutdown?(): Promise<void>;
+}
+
+export interface StartCliHostInput {
+  options: CliOptions;
+  runtime: CliRuntimeSettings;
+}
+
+export interface CliIo {
+  stdout(message: string): void;
+  stderr(message: string): void;
+}
+
+export interface CliDependencies {
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+  io?: CliIo;
+  loadWorkflowDefinition?: typeof loadWorkflowDefinition;
+  resolveWorkflowConfig?: typeof resolveWorkflowConfig;
+  startHost?: (input: StartCliHostInput) => Promise<CliHost>;
+}
+
+export class CliUsageError extends Error {
+  readonly code = ERROR_CODES.cliStartupFailed;
+
+  constructor(message: string) {
+    super(message);
+    this.name = "CliUsageError";
+  }
+}
+
+export function parseCliArgs(argv: readonly string[]): CliOptions {
+  let workflowPath: string | null = null;
+  let logsRoot: string | null = null;
+  let port: number | null = null;
+  let acknowledged = false;
+  let help = false;
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (token === undefined) {
+      continue;
+    }
+
+    if (!token.startsWith("-")) {
+      if (workflowPath !== null) {
+        throw new CliUsageError(
+          "CLI accepts at most one positional workflow path argument.",
+        );
+      }
+
+      workflowPath = token;
+      continue;
+    }
+
+    if (token === "--help" || token === "-h") {
+      help = true;
+      continue;
+    }
+
+    if (token === CLI_ACKNOWLEDGEMENT_FLAG) {
+      acknowledged = true;
+      continue;
+    }
+
+    if (token === "--logs-root") {
+      logsRoot = readValueFlag(argv, ++index, "--logs-root");
+      continue;
+    }
+
+    if (token.startsWith("--logs-root=")) {
+      logsRoot = token.slice("--logs-root=".length);
+      ensureFlagValue(logsRoot, "--logs-root");
+      continue;
+    }
+
+    if (token === "--port") {
+      port = parsePort(readValueFlag(argv, ++index, "--port"));
+      continue;
+    }
+
+    if (token.startsWith("--port=")) {
+      port = parsePort(token.slice("--port=".length));
+      continue;
+    }
+
+    throw new CliUsageError(`Unknown CLI argument: ${token}`);
+  }
+
+  return {
+    workflowPath,
+    logsRoot,
+    port,
+    acknowledged,
+    help,
+  };
+}
+
+export function applyCliOverrides(
+  config: ReturnType<typeof resolveWorkflowConfig>,
+  options: CliOptions,
+  cwd = process.cwd(),
+): CliRuntimeSettings {
+  return {
+    config: {
+      ...config,
+      server: {
+        ...config.server,
+        port: options.port ?? config.server.port,
+      },
+    },
+    logsRoot: options.logsRoot === null ? null : resolve(cwd, options.logsRoot),
+  };
+}
+
+export async function startCliHost(
+  input: StartCliHostInput,
+): Promise<RuntimeServiceHandle> {
+  return startRuntimeService({
+    config: input.runtime.config,
+    logsRoot: input.runtime.logsRoot,
+  });
+}
+
+export async function runCli(
+  argv: readonly string[],
+  dependencies: CliDependencies = {},
+): Promise<number> {
+  const cwd = dependencies.cwd ?? process.cwd();
+  const env = dependencies.env ?? process.env;
+  const io = dependencies.io ?? {
+    stdout: (message: string) => process.stdout.write(message),
+    stderr: (message: string) => process.stderr.write(message),
+  };
+  const loadWorkflow =
+    dependencies.loadWorkflowDefinition ?? loadWorkflowDefinition;
+  const resolveConfig =
+    dependencies.resolveWorkflowConfig ?? resolveWorkflowConfig;
+  const startHost = dependencies.startHost ?? startCliHost;
+
+  let options: CliOptions;
+  try {
+    options = parseCliArgs(argv);
+  } catch (error) {
+    io.stderr(`${formatCliError(error)}\n${renderUsage()}`);
+    return 1;
+  }
+
+  if (options.help) {
+    io.stdout(renderUsage());
+    return 0;
+  }
+
+  if (!options.acknowledged) {
+    io.stderr(
+      `Refusing to start without ${CLI_ACKNOWLEDGEMENT_FLAG}. Symphony is a high-trust preview intended for trusted environments.\n`,
+    );
+    return 1;
+  }
+
+  try {
+    const workflowPath =
+      options.workflowPath === null
+        ? resolve(cwd, WORKFLOW_FILENAME)
+        : resolve(cwd, options.workflowPath);
+    const workflow = await loadWorkflow(workflowPath);
+    const config = resolveConfig(workflow, env);
+    const runtime = applyCliOverrides(config, options, cwd);
+    const host = await startHost({
+      options,
+      runtime,
+    });
+    const exitCode = await host.waitForExit();
+
+    if (typeof exitCode === "number" && exitCode !== 0) {
+      io.stderr(`Symphony host exited abnormally with code ${exitCode}.\n`);
+      return exitCode;
+    }
+
+    return 0;
+  } catch (error) {
+    io.stderr(`${formatCliError(error)}\n`);
+    return 1;
+  }
+}
+
+export async function main(): Promise<void> {
+  const exitCode = await runCli(process.argv.slice(2));
+  process.exitCode = exitCode;
+}
+
+function readValueFlag(
+  argv: readonly string[],
+  index: number,
+  flag: string,
+): string {
+  const value = argv[index];
+  ensureFlagValue(value, flag);
+  return value;
+}
+
+function ensureFlagValue(
+  value: string | undefined,
+  flag: string,
+): asserts value is string {
+  if (!value || value.startsWith("-")) {
+    throw new CliUsageError(`Missing value for ${flag}.`);
+  }
+}
+
+function parsePort(rawPort: string): number {
+  if (!/^\d+$/.test(rawPort.trim())) {
+    throw new CliUsageError(`Invalid value for --port: ${rawPort}`);
+  }
+
+  return Number.parseInt(rawPort, 10);
+}
+
+function formatCliError(error: unknown): string {
+  if (error instanceof Error && error.message) {
+    return error.message;
+  }
+
+  return "Symphony failed to start.";
+}
+
+function renderUsage(): string {
+  return [
+    "Usage: symphony [path-to-WORKFLOW.md] [options]",
+    "",
+    "Options:",
+    `  ${CLI_ACKNOWLEDGEMENT_FLAG}  required before startup`,
+    "  --logs-root <path>           override the logs root directory",
+    "  --port <number>              override the HTTP server port",
+    "  --help                       show this help text",
+    "",
+  ].join("\n");
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  void main();
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./agent/prompt-builder.js";
 export * from "./agent/runner.js";
+export * from "./cli/main.js";
 export * from "./config/defaults.js";
 export * from "./config/config-resolver.js";
 export * from "./config/types.js";

--- a/src/orchestrator/runtime-host.ts
+++ b/src/orchestrator/runtime-host.ts
@@ -1,21 +1,34 @@
+import { createWriteStream } from "node:fs";
+import { mkdir } from "node:fs/promises";
+import { join } from "node:path";
+import type { Writable } from "node:stream";
+
 import type { AgentRunResult, AgentRunnerEvent } from "../agent/runner.js";
 import { AgentRunner } from "../agent/runner.js";
+import { validateDispatchConfig } from "../config/config-resolver.js";
 import type { ResolvedWorkflowConfig } from "../config/types.js";
 import type { Issue, RetryEntry, RunningEntry } from "../domain/model.js";
+import { ERROR_CODES } from "../errors/codes.js";
 import {
   type RuntimeSnapshot,
   buildRuntimeSnapshot,
 } from "../logging/runtime-snapshot.js";
-import type {
-  DashboardServerHost,
-  IssueDetailResponse,
-  RefreshResponse,
+import {
+  StructuredLogger,
+  createJsonLineSink,
+} from "../logging/structured-logger.js";
+import {
+  type DashboardServerHost,
+  type DashboardServerInstance,
+  type IssueDetailResponse,
+  type RefreshResponse,
+  startDashboardServer,
 } from "../observability/dashboard-server.js";
+import { LinearTrackerClient } from "../tracker/linear-client.js";
 import type { IssueTracker } from "../tracker/tracker.js";
 import { WorkspaceManager } from "../workspace/workspace-manager.js";
 import type {
   OrchestratorCoreOptions,
-  StopReason,
   StopRequest,
   TimerScheduler,
 } from "./core.js";
@@ -40,6 +53,25 @@ export interface RuntimeHostOptions {
   now?: () => Date;
 }
 
+export interface RuntimeServiceOptions {
+  config: ResolvedWorkflowConfig;
+  logsRoot?: string | null;
+  tracker?: IssueTracker;
+  runtimeHost?: OrchestratorRuntimeHost;
+  workspaceManager?: WorkspaceManager;
+  now?: () => Date;
+  logger?: StructuredLogger;
+  stdout?: Writable;
+}
+
+export interface RuntimeServiceHandle {
+  readonly runtimeHost: OrchestratorRuntimeHost;
+  readonly logger: StructuredLogger;
+  readonly dashboard: DashboardServerInstance | null;
+  waitForExit(): Promise<number>;
+  shutdown(): Promise<void>;
+}
+
 interface WorkerExecution {
   issueId: string;
   issueIdentifier: string;
@@ -47,6 +79,16 @@ interface WorkerExecution {
   completion: Promise<void>;
   stopRequest: StopRequest | null;
   lastResult: AgentRunResult | null;
+}
+
+export class RuntimeHostStartupError extends Error {
+  readonly code: string;
+
+  constructor(message: string, code: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = "RuntimeHostStartupError";
+    this.code = code;
+  }
 }
 
 export class OrchestratorRuntimeHost implements DashboardServerHost {
@@ -168,7 +210,7 @@ export class OrchestratorRuntimeHost implements DashboardServerHost {
       (entry) => entry.identifier === issueIdentifier,
     );
     if (running !== undefined) {
-      return toRunningIssueDetail(running);
+      return toRunningIssueDetail(running, this.workspaceManager);
     }
 
     const retry = Object.values(
@@ -299,6 +341,188 @@ export class OrchestratorRuntimeHost implements DashboardServerHost {
   }
 }
 
+export async function startRuntimeService(
+  options: RuntimeServiceOptions,
+): Promise<RuntimeServiceHandle> {
+  const validation = validateDispatchConfig(options.config);
+  if (!validation.ok) {
+    throw new RuntimeHostStartupError(
+      validation.error.message,
+      validation.error.code,
+    );
+  }
+
+  const tracker =
+    options.tracker ??
+    new LinearTrackerClient({
+      endpoint: options.config.tracker.endpoint,
+      apiKey: options.config.tracker.apiKey,
+      projectSlug: options.config.tracker.projectSlug,
+      activeStates: options.config.tracker.activeStates,
+    });
+  const workspaceManager =
+    options.workspaceManager ??
+    new WorkspaceManager({
+      root: options.config.workspace.root,
+    });
+  const logger =
+    options.logger ??
+    (await createRuntimeLogger({
+      logsRoot: options.logsRoot ?? null,
+      ...(options.stdout === undefined ? {} : { stdout: options.stdout }),
+    }));
+  const runtimeHost =
+    options.runtimeHost ??
+    new OrchestratorRuntimeHost({
+      config: options.config,
+      tracker,
+      workspaceManager,
+      ...(options.now === undefined ? {} : { now: options.now }),
+    });
+
+  await cleanupTerminalIssueWorkspaces({
+    tracker,
+    terminalStates: options.config.tracker.terminalStates,
+    workspaceManager,
+    logger,
+  });
+
+  const dashboard =
+    options.config.server.port === null
+      ? null
+      : await startDashboardServer({
+          host: runtimeHost,
+          port: options.config.server.port,
+        });
+
+  const stopController = new AbortController();
+  const exitPromise = createExitPromise();
+  let pollTimer: NodeJS.Timeout | null = null;
+  let shuttingDown = false;
+
+  const scheduleNextPoll = () => {
+    if (stopController.signal.aborted) {
+      return;
+    }
+
+    pollTimer = setTimeout(() => {
+      void runPollCycle();
+    }, options.config.polling.intervalMs);
+  };
+
+  const runPollCycle = async () => {
+    try {
+      await runtimeHost.pollOnce();
+      scheduleNextPoll();
+    } catch (error) {
+      await logger.error("runtime_poll_failed", toErrorMessage(error), {
+        error_code: ERROR_CODES.cliStartupFailed,
+      });
+      resolveExit(exitPromise, 1);
+      void shutdown();
+    }
+  };
+
+  const onSignal = (signal: NodeJS.Signals) => {
+    void logger.info("runtime_shutdown_signal", `received ${signal}`, {
+      reason: signal,
+    });
+    resolveExit(exitPromise, 0);
+    void shutdown();
+  };
+
+  const removeSignalHandlers = installSignalHandlers(onSignal);
+
+  const shutdown = async () => {
+    if (shuttingDown) {
+      await exitPromise.closed;
+      return;
+    }
+    shuttingDown = true;
+    resolveExit(exitPromise, 0);
+    stopController.abort();
+
+    if (pollTimer !== null) {
+      clearTimeout(pollTimer);
+      pollTimer = null;
+    }
+
+    removeSignalHandlers();
+
+    await Promise.allSettled([
+      runtimeHost.waitForIdle(),
+      dashboard?.close() ?? Promise.resolve(),
+    ]);
+
+    resolveClosed(exitPromise);
+  };
+
+  await logger.info("runtime_starting", "Symphony runtime started.", {
+    poll_interval_ms: options.config.polling.intervalMs,
+    max_concurrent_agents: options.config.agent.maxConcurrentAgents,
+    ...(dashboard === null ? {} : { port: dashboard.port }),
+  });
+
+  void runPollCycle();
+
+  return {
+    runtimeHost,
+    logger,
+    dashboard,
+    async waitForExit() {
+      return exitPromise.exitCode;
+    },
+    shutdown,
+  };
+}
+
+async function cleanupTerminalIssueWorkspaces(input: {
+  tracker: IssueTracker;
+  terminalStates: string[];
+  workspaceManager: WorkspaceManager;
+  logger: StructuredLogger;
+}): Promise<void> {
+  try {
+    const issues = await input.tracker.fetchIssuesByStates(
+      input.terminalStates,
+    );
+    await Promise.all(
+      issues.map(async (issue) => {
+        await input.workspaceManager.removeForIssue(issue.identifier);
+      }),
+    );
+  } catch (error) {
+    await input.logger.warn(
+      "startup_terminal_cleanup_failed",
+      toErrorMessage(error),
+      {
+        outcome: "degraded",
+        reason: "startup_terminal_cleanup_failed",
+      },
+    );
+  }
+}
+
+async function createRuntimeLogger(input: {
+  logsRoot: string | null;
+  stdout?: Writable;
+}): Promise<StructuredLogger> {
+  const sinks = [createJsonLineSink(input.stdout ?? process.stdout)];
+
+  if (input.logsRoot !== null) {
+    await mkdir(input.logsRoot, { recursive: true });
+    sinks.push(
+      createJsonLineSink(
+        createWriteStream(join(input.logsRoot, "symphony.jsonl"), {
+          flags: "a",
+        }),
+      ),
+    );
+  }
+
+  return new StructuredLogger(sinks);
+}
+
 function createQueuedTimerScheduler(input: {
   run: (callback: () => void) => void;
 }): TimerScheduler {
@@ -316,13 +540,16 @@ function createQueuedTimerScheduler(input: {
   };
 }
 
-function toRunningIssueDetail(running: RunningEntry): IssueDetailResponse {
+function toRunningIssueDetail(
+  running: RunningEntry,
+  workspaceManager: WorkspaceManager,
+): IssueDetailResponse {
   return {
     issue_identifier: running.identifier,
     issue_id: running.issue.id,
     status: "running",
     workspace: {
-      path: "",
+      path: workspaceManager.resolveForIssue(running.identifier).workspacePath,
     },
     attempts: {
       restart_count: running.retryAttempt ?? 0,
@@ -378,6 +605,61 @@ function toRetryIssueDetail(
     last_error: retry.error,
     tracked: {},
   };
+}
+
+function installSignalHandlers(
+  onSignal: (signal: NodeJS.Signals) => void,
+): () => void {
+  const signals: NodeJS.Signals[] = ["SIGINT", "SIGTERM"];
+  for (const signal of signals) {
+    process.on(signal, onSignal);
+  }
+
+  return () => {
+    for (const signal of signals) {
+      process.off(signal, onSignal);
+    }
+  };
+}
+
+function createExitPromise(): {
+  exitCode: Promise<number>;
+  closed: Promise<void>;
+  resolveExit: (code: number) => void;
+  resolveClosed: () => void;
+} {
+  let resolveExitCode: ((code: number) => void) | null = null;
+  let resolveClosedPromise: (() => void) | null = null;
+
+  return {
+    exitCode: new Promise<number>((resolve) => {
+      resolveExitCode = resolve;
+    }),
+    closed: new Promise<void>((resolve) => {
+      resolveClosedPromise = resolve;
+    }),
+    resolveExit(code) {
+      resolveExitCode?.(code);
+      resolveExitCode = null;
+    },
+    resolveClosed() {
+      resolveClosedPromise?.();
+      resolveClosedPromise = null;
+    },
+  };
+}
+
+function resolveExit(
+  exitPromise: ReturnType<typeof createExitPromise>,
+  code: number,
+): void {
+  exitPromise.resolveExit(code);
+}
+
+function resolveClosed(
+  exitPromise: ReturnType<typeof createExitPromise>,
+): void {
+  exitPromise.resolveClosed();
 }
 
 function toErrorMessage(error: unknown): string {

--- a/tests/agent/runner.test.ts
+++ b/tests/agent/runner.test.ts
@@ -213,38 +213,48 @@ describe("AgentRunner", () => {
     });
   });
 
-  it("cancels the active run when aborted externally", async () => {
+  it("cancels the run when the orchestrator aborts the worker signal", async () => {
     const root = await createRoot();
     const close = vi.fn().mockResolvedValue(undefined);
     const controller = new AbortController();
     const runner = new AgentRunner({
       config: createConfig(root, "unused"),
-      tracker: createTracker(),
-      createCodexClient: (input) => ({
-        async startSession({ prompt, title }) {
-          return await new Promise((resolve, reject) => {
-            input.onEvent({
-              event: "session_started",
-              timestamp: new Date("2026-03-06T00:00:00.000Z").toISOString(),
-              codexAppServerPid: "1001",
-              sessionId: "thread-1-turn-1",
-              threadId: "thread-1",
-              turnId: "turn-1",
-            });
-            controller.signal.addEventListener(
-              "abort",
-              () => {
-                reject(new Error("Stopped due to terminal_state."));
-              },
-              { once: true },
-            );
-          });
-        },
-        async continueTurn() {
-          throw new Error("unexpected continuation turn");
-        },
-        close,
+      tracker: createTracker({
+        refreshStates: [
+          { id: "issue-1", identifier: "ABC-123", state: "In Progress" },
+        ],
       }),
+      createCodexClient: (input) =>
+        createStubCodexClient([], input, {
+          close,
+          startSession: async ({
+            prompt,
+          }: {
+            prompt: string;
+            title: string;
+          }) =>
+            await new Promise((resolve, reject) => {
+              const timeout = setTimeout(() => {
+                resolve({
+                  status: "completed" as const,
+                  threadId: "thread-1",
+                  turnId: "turn-1",
+                  sessionId: "thread-1-turn-1",
+                  usage: null,
+                  rateLimits: null,
+                  message: prompt,
+                });
+              }, 500);
+              controller.signal.addEventListener(
+                "abort",
+                () => {
+                  clearTimeout(timeout);
+                  reject(new Error("Stopped due to terminal_state."));
+                },
+                { once: true },
+              );
+            }),
+        }),
     });
 
     const pending = runner.run({
@@ -257,6 +267,7 @@ describe("AgentRunner", () => {
     await expect(pending).rejects.toMatchObject({
       name: "AgentRunnerError",
       status: "canceled_by_reconciliation",
+      failedPhase: "launching_agent_process",
       message: "Stopped due to terminal_state.",
     } satisfies Partial<AgentRunnerError>);
     expect(close).toHaveBeenCalled();
@@ -269,13 +280,30 @@ function createStubCodexClient(
   overrides?: Partial<{
     close: ReturnType<typeof vi.fn>;
     statuses: Array<"completed" | "failed" | "cancelled">;
+    startSession: (input: { prompt: string; title: string }) => Promise<{
+      status: "completed" | "failed" | "cancelled";
+      threadId: string;
+      turnId: string;
+      sessionId: string;
+      usage: {
+        inputTokens: number;
+        outputTokens: number;
+        totalTokens: number;
+      } | null;
+      rateLimits: Record<string, unknown> | null;
+      message: string | null;
+    }>;
   }>,
 ) {
   let turn = 0;
   const statuses = overrides?.statuses ?? ["completed"];
 
   return {
-    async startSession({ prompt }: { prompt: string; title: string }) {
+    async startSession({ prompt, title }: { prompt: string; title: string }) {
+      if (overrides?.startSession) {
+        return overrides.startSession({ prompt, title });
+      }
+
       turn += 1;
       prompts.push(prompt);
       input.onEvent({

--- a/tests/cli/main.test.ts
+++ b/tests/cli/main.test.ts
@@ -1,0 +1,242 @@
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  CLI_ACKNOWLEDGEMENT_FLAG,
+  applyCliOverrides,
+  parseCliArgs,
+  runCli,
+} from "../../src/cli/main.js";
+import type { ResolvedWorkflowConfig } from "../../src/config/types.js";
+
+describe("cli", () => {
+  it("parses the workflow path and CLI override flags", () => {
+    expect(
+      parseCliArgs([
+        "config/WORKFLOW.md",
+        "--logs-root",
+        "./logs",
+        "--port=8080",
+        CLI_ACKNOWLEDGEMENT_FLAG,
+      ]),
+    ).toEqual({
+      workflowPath: "config/WORKFLOW.md",
+      logsRoot: "./logs",
+      port: 8080,
+      acknowledged: true,
+      help: false,
+    });
+  });
+
+  it("rejects unknown flags and duplicate positional arguments", () => {
+    expect(() => parseCliArgs(["--unknown"])).toThrowError(
+      "Unknown CLI argument: --unknown",
+    );
+    expect(() => parseCliArgs(["one.md", "two.md"])).toThrowError(
+      "CLI accepts at most one positional workflow path argument.",
+    );
+  });
+
+  it("applies CLI overrides with port precedence and absolute logs root", () => {
+    const runtime = applyCliOverrides(
+      createConfig({
+        server: {
+          port: 3000,
+        },
+      }),
+      {
+        workflowPath: null,
+        logsRoot: "./runtime-logs",
+        port: 8080,
+        acknowledged: true,
+        help: false,
+      },
+      "/repo",
+    );
+
+    expect(runtime.config.server.port).toBe(8080);
+    expect(runtime.logsRoot).toBe("/repo/runtime-logs");
+  });
+
+  it("defaults to loading ./WORKFLOW.md from cwd when no workflow path is given", async () => {
+    const workspace = await mkdtemp(join(tmpdir(), "symphony-task16-cli-"));
+    const workflowPath = join(workspace, "WORKFLOW.md");
+    await writeFile(workflowPath, "Prompt body\n", "utf8");
+
+    const startHost = vi.fn(async () => ({
+      async waitForExit() {
+        return 0;
+      },
+    }));
+
+    const exitCode = await runCli([CLI_ACKNOWLEDGEMENT_FLAG], {
+      cwd: workspace,
+      env: {},
+      startHost,
+    });
+
+    expect(exitCode).toBe(0);
+    expect(startHost).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runtime: expect.objectContaining({
+          config: expect.objectContaining({
+            workflowPath,
+          }),
+        }),
+      }),
+    );
+  });
+
+  it("returns nonzero and skips startup when acknowledgement is missing", async () => {
+    const stderr = vi.fn();
+    const startHost = vi.fn();
+
+    const exitCode = await runCli([], {
+      io: {
+        stdout: vi.fn(),
+        stderr,
+      },
+      startHost,
+    });
+
+    expect(exitCode).toBe(1);
+    expect(startHost).not.toHaveBeenCalled();
+    expect(stderr).toHaveBeenCalledWith(
+      expect.stringContaining(CLI_ACKNOWLEDGEMENT_FLAG),
+    );
+  });
+
+  it("returns nonzero when the workflow file is missing", async () => {
+    const stderr = vi.fn();
+
+    const exitCode = await runCli(["missing.md", CLI_ACKNOWLEDGEMENT_FLAG], {
+      io: {
+        stdout: vi.fn(),
+        stderr,
+      },
+    });
+
+    expect(exitCode).toBe(1);
+    expect(stderr).toHaveBeenCalledWith(
+      expect.stringContaining("Unable to read workflow file"),
+    );
+  });
+
+  it("returns success when the host starts and shuts down normally", async () => {
+    const startHost = vi.fn(async () => ({
+      async waitForExit() {
+        return 0;
+      },
+    }));
+
+    const exitCode = await runCli([CLI_ACKNOWLEDGEMENT_FLAG], {
+      env: {},
+      loadWorkflowDefinition: vi.fn(async () => ({
+        workflowPath: "/repo/WORKFLOW.md",
+        config: {},
+        promptTemplate: "Prompt",
+      })),
+      startHost,
+    });
+
+    expect(exitCode).toBe(0);
+    expect(startHost).toHaveBeenCalledOnce();
+  });
+
+  it("returns nonzero when startup fails or the host exits abnormally", async () => {
+    const stderr = vi.fn();
+
+    const startupFailure = await runCli([CLI_ACKNOWLEDGEMENT_FLAG], {
+      io: {
+        stdout: vi.fn(),
+        stderr,
+      },
+      env: {},
+      loadWorkflowDefinition: vi.fn(async () => ({
+        workflowPath: "/repo/WORKFLOW.md",
+        config: {},
+        promptTemplate: "Prompt",
+      })),
+      startHost: vi.fn(async () => {
+        throw new Error("boom");
+      }),
+    });
+
+    const abnormalExit = await runCli([CLI_ACKNOWLEDGEMENT_FLAG], {
+      io: {
+        stdout: vi.fn(),
+        stderr,
+      },
+      env: {},
+      loadWorkflowDefinition: vi.fn(async () => ({
+        workflowPath: "/repo/WORKFLOW.md",
+        config: {},
+        promptTemplate: "Prompt",
+      })),
+      startHost: vi.fn(async () => ({
+        async waitForExit() {
+          return 3;
+        },
+      })),
+    });
+
+    expect(startupFailure).toBe(1);
+    expect(abnormalExit).toBe(3);
+    expect(stderr).toHaveBeenCalledWith(expect.stringContaining("boom"));
+    expect(stderr).toHaveBeenCalledWith(
+      "Symphony host exited abnormally with code 3.\n",
+    );
+  });
+});
+
+function createConfig(
+  overrides: Partial<ResolvedWorkflowConfig> = {},
+): ResolvedWorkflowConfig {
+  return {
+    workflowPath: "/repo/WORKFLOW.md",
+    promptTemplate: "Prompt",
+    tracker: {
+      kind: "linear",
+      endpoint: "https://api.linear.app/graphql",
+      apiKey: "token",
+      projectSlug: "ENG",
+      activeStates: ["Todo"],
+      terminalStates: ["Done"],
+    },
+    polling: {
+      intervalMs: 30_000,
+    },
+    workspace: {
+      root: "/tmp/symphony",
+    },
+    hooks: {
+      afterCreate: null,
+      beforeRun: null,
+      afterRun: null,
+      beforeRemove: null,
+      timeoutMs: 60_000,
+    },
+    agent: {
+      maxConcurrentAgents: 10,
+      maxTurns: 20,
+      maxRetryBackoffMs: 300_000,
+      maxConcurrentAgentsByState: {},
+    },
+    codex: {
+      command: "codex app-server",
+      approvalPolicy: null,
+      threadSandbox: null,
+      turnSandboxPolicy: null,
+      turnTimeoutMs: 3_600_000,
+      readTimeoutMs: 5_000,
+      stallTimeoutMs: 300_000,
+    },
+    server: {
+      port: null,
+    },
+    ...overrides,
+  };
+}


### PR DESCRIPTION
## Summary
- add the CLI entrypoint for workflow path, logs root, port, and acknowledgement handling
- add a runtime host that wires orchestrator polling, startup cleanup, and optional dashboard startup
- extend agent/orchestrator integration for codex event propagation and worker cancellation support

## Testing
- pnpm lint
- pnpm typecheck
- pnpm test