### PR TITLE
Complete task 18 integration hardening

### DIFF
--- a/src/orchestrator/core.ts
+++ b/src/orchestrator/core.ts
@@ -84,7 +84,7 @@ export interface OrchestratorCoreOptions {
 export class OrchestratorCore {
   private config: ResolvedWorkflowConfig;
 
-  private readonly tracker: IssueTracker;
+  private tracker: IssueTracker;
 
   private readonly spawnWorker: OrchestratorCoreOptions["spawnWorker"];
 
@@ -116,6 +116,10 @@ export class OrchestratorCore {
   updateConfig(config: ResolvedWorkflowConfig): void {
     this.config = config;
     this.syncStateFromConfig();
+  }
+
+  updateTracker(tracker: IssueTracker): void {
+    this.tracker = tracker;
   }
 
   isDispatchEligible(

--- a/src/orchestrator/runtime-host.ts
+++ b/src/orchestrator/runtime-host.ts
@@ -1,5 +1,5 @@
 import { createWriteStream } from "node:fs";
-import { mkdir } from "node:fs/promises";
+import { access, mkdir } from "node:fs/promises";
 import { join } from "node:path";
 import type { Writable } from "node:stream";
 
@@ -7,6 +7,7 @@ import type { AgentRunResult, AgentRunnerEvent } from "../agent/runner.js";
 import { AgentRunner } from "../agent/runner.js";
 import { validateDispatchConfig } from "../config/config-resolver.js";
 import type { ResolvedWorkflowConfig } from "../config/types.js";
+import { WorkflowWatcher } from "../config/workflow-watch.js";
 import type { Issue, RetryEntry, RunningEntry } from "../domain/model.js";
 import { ERROR_CODES } from "../errors/codes.js";
 import {
@@ -26,6 +27,7 @@ import {
 } from "../observability/dashboard-server.js";
 import { LinearTrackerClient } from "../tracker/linear-client.js";
 import type { IssueTracker } from "../tracker/tracker.js";
+import { WorkspaceHookRunner } from "../workspace/hooks.js";
 import { WorkspaceManager } from "../workspace/workspace-manager.js";
 import type {
   OrchestratorCoreOptions,
@@ -59,6 +61,7 @@ export interface RuntimeServiceOptions {
   tracker?: IssueTracker;
   runtimeHost?: OrchestratorRuntimeHost;
   workspaceManager?: WorkspaceManager;
+  workflowWatcher?: WorkflowWatcher | null;
   now?: () => Date;
   logger?: StructuredLogger;
   stdout?: Writable;
@@ -92,19 +95,23 @@ export class RuntimeHostStartupError extends Error {
 }
 
 export class OrchestratorRuntimeHost implements DashboardServerHost {
-  private readonly config: ResolvedWorkflowConfig;
+  private config: ResolvedWorkflowConfig;
 
-  private readonly tracker: IssueTracker;
+  private tracker: IssueTracker;
 
-  private readonly workspaceManager: WorkspaceManager;
+  private workspaceManager: WorkspaceManager;
 
-  private readonly agentRunner: AgentRunnerLike;
+  private agentRunner: AgentRunnerLike;
 
   private readonly now: () => Date;
 
   private readonly workers = new Map<string, WorkerExecution>();
 
   private readonly orchestrator: OrchestratorCore;
+
+  private readonly managesAgentRunner: boolean;
+
+  private readonly agentEventSink: (event: AgentRunnerEvent) => void;
 
   private eventQueue: Promise<unknown> = Promise.resolve();
 
@@ -116,33 +123,27 @@ export class OrchestratorRuntimeHost implements DashboardServerHost {
     this.now = options.now ?? (() => new Date());
     this.workspaceManager =
       options.workspaceManager ??
-      new WorkspaceManager({
-        root: options.config.workspace.root,
+      createWorkspaceManagerFromConfig(options.config);
+    this.agentEventSink = (event) => {
+      void this.enqueue(async () => {
+        this.orchestrator.onCodexEvent({
+          issueId: event.issueId,
+          event,
+        });
       });
+    };
+    this.managesAgentRunner =
+      options.agentRunner === undefined &&
+      options.createAgentRunner === undefined;
     this.agentRunner =
       options.agentRunner ??
       options.createAgentRunner?.({
-        onEvent: (event) => {
-          void this.enqueue(async () => {
-            this.orchestrator.onCodexEvent({
-              issueId: event.issueId,
-              event,
-            });
-          });
-        },
+        onEvent: this.agentEventSink,
       }) ??
-      new AgentRunner({
+      this.createManagedAgentRunner({
         config: options.config,
         tracker: options.tracker,
         workspaceManager: this.workspaceManager,
-        onEvent: (event) => {
-          void this.enqueue(async () => {
-            this.orchestrator.onCodexEvent({
-              issueId: event.issueId,
-              event,
-            });
-          });
-        },
       });
 
     const timerScheduler = createQueuedTimerScheduler({
@@ -175,6 +176,44 @@ export class OrchestratorRuntimeHost implements DashboardServerHost {
 
   getState() {
     return this.orchestrator.getState();
+  }
+
+  updateConfig(input: {
+    config: ResolvedWorkflowConfig;
+    tracker?: IssueTracker;
+    workspaceManager?: WorkspaceManager;
+  }): void {
+    this.config = input.config;
+
+    if (input.tracker !== undefined) {
+      this.tracker = input.tracker;
+      this.orchestrator.updateTracker(input.tracker);
+    }
+
+    if (input.workspaceManager !== undefined) {
+      this.workspaceManager = input.workspaceManager;
+    }
+
+    this.orchestrator.updateConfig(input.config);
+
+    if (this.managesAgentRunner) {
+      this.agentRunner = this.createManagedAgentRunner({
+        config: this.config,
+        tracker: this.tracker,
+        workspaceManager: this.workspaceManager,
+      });
+      return;
+    }
+
+    if (supportsConfigUpdate(this.agentRunner)) {
+      this.agentRunner.updateConfig({
+        config: this.config,
+        ...(input.tracker === undefined ? {} : { tracker: this.tracker }),
+        ...(input.workspaceManager === undefined
+          ? {}
+          : { workspaceManager: this.workspaceManager }),
+      });
+    }
   }
 
   async pollOnce() {
@@ -339,6 +378,19 @@ export class OrchestratorRuntimeHost implements DashboardServerHost {
     );
     return next;
   }
+
+  private createManagedAgentRunner(input: {
+    config: ResolvedWorkflowConfig;
+    tracker: IssueTracker;
+    workspaceManager: WorkspaceManager;
+  }): AgentRunnerLike {
+    return new AgentRunner({
+      config: input.config,
+      tracker: input.tracker,
+      workspaceManager: input.workspaceManager,
+      onEvent: this.agentEventSink,
+    });
+  }
 }
 
 export async function startRuntimeService(
@@ -352,19 +404,10 @@ export async function startRuntimeService(
     );
   }
 
-  const tracker =
-    options.tracker ??
-    new LinearTrackerClient({
-      endpoint: options.config.tracker.endpoint,
-      apiKey: options.config.tracker.apiKey,
-      projectSlug: options.config.tracker.projectSlug,
-      activeStates: options.config.tracker.activeStates,
-    });
-  const workspaceManager =
-    options.workspaceManager ??
-    new WorkspaceManager({
-      root: options.config.workspace.root,
-    });
+  let currentConfig = options.config;
+  let tracker = options.tracker ?? createLinearTrackerFromConfig(currentConfig);
+  let workspaceManager =
+    options.workspaceManager ?? createWorkspaceManagerFromConfig(currentConfig);
   const logger =
     options.logger ??
     (await createRuntimeLogger({
@@ -374,25 +417,27 @@ export async function startRuntimeService(
   const runtimeHost =
     options.runtimeHost ??
     new OrchestratorRuntimeHost({
-      config: options.config,
+      config: currentConfig,
       tracker,
       workspaceManager,
       ...(options.now === undefined ? {} : { now: options.now }),
     });
+  const usesManagedTracker = options.tracker === undefined;
+  const usesManagedWorkspaceManager = options.workspaceManager === undefined;
 
   await cleanupTerminalIssueWorkspaces({
     tracker,
-    terminalStates: options.config.tracker.terminalStates,
+    terminalStates: currentConfig.tracker.terminalStates,
     workspaceManager,
     logger,
   });
 
   const dashboard =
-    options.config.server.port === null
+    currentConfig.server.port === null
       ? null
       : await startDashboardServer({
           host: runtimeHost,
-          port: options.config.server.port,
+          port: currentConfig.server.port,
         });
 
   const stopController = new AbortController();
@@ -407,7 +452,7 @@ export async function startRuntimeService(
 
     pollTimer = setTimeout(() => {
       void runPollCycle();
-    }, options.config.polling.intervalMs);
+    }, currentConfig.polling.intervalMs);
   };
 
   const runPollCycle = async () => {
@@ -432,6 +477,53 @@ export async function startRuntimeService(
   };
 
   const removeSignalHandlers = installSignalHandlers(onSignal);
+  const workflowWatcher =
+    options.workflowWatcher === undefined
+      ? await createRuntimeWorkflowWatcher({
+          config: currentConfig,
+          logger,
+          onReload: async (nextConfig) => {
+            const previousConfig = currentConfig;
+            currentConfig = nextConfig;
+
+            if (usesManagedTracker) {
+              tracker = createLinearTrackerFromConfig(nextConfig);
+            }
+
+            if (usesManagedWorkspaceManager) {
+              workspaceManager = createWorkspaceManagerFromConfig(nextConfig);
+            }
+
+            runtimeHost.updateConfig({
+              config: nextConfig,
+              ...(usesManagedTracker ? { tracker } : {}),
+              ...(usesManagedWorkspaceManager ? { workspaceManager } : {}),
+            });
+
+            if (pollTimer !== null) {
+              clearTimeout(pollTimer);
+              pollTimer = null;
+              scheduleNextPoll();
+            }
+
+            if (
+              dashboard !== null &&
+              previousConfig.server.port !== nextConfig.server.port
+            ) {
+              await logger.warn(
+                "workflow_reload_port_ignored",
+                "Ignoring server.port change until runtime restart.",
+                {
+                  outcome: "degraded",
+                  reason: "server_port_reload_requires_restart",
+                  port: dashboard.port,
+                },
+              );
+            }
+          },
+        })
+      : options.workflowWatcher;
+  workflowWatcher?.start();
 
   const shutdown = async () => {
     if (shuttingDown) {
@@ -452,14 +544,15 @@ export async function startRuntimeService(
     await Promise.allSettled([
       runtimeHost.waitForIdle(),
       dashboard?.close() ?? Promise.resolve(),
+      workflowWatcher?.close() ?? Promise.resolve(),
     ]);
 
     resolveClosed(exitPromise);
   };
 
   await logger.info("runtime_starting", "Symphony runtime started.", {
-    poll_interval_ms: options.config.polling.intervalMs,
-    max_concurrent_agents: options.config.agent.maxConcurrentAgents,
+    poll_interval_ms: currentConfig.polling.intervalMs,
+    max_concurrent_agents: currentConfig.agent.maxConcurrentAgents,
     ...(dashboard === null ? {} : { port: dashboard.port }),
   });
 
@@ -474,6 +567,55 @@ export async function startRuntimeService(
     },
     shutdown,
   };
+}
+
+async function createRuntimeWorkflowWatcher(input: {
+  config: ResolvedWorkflowConfig;
+  logger: StructuredLogger;
+  onReload: (config: ResolvedWorkflowConfig) => Promise<void>;
+}): Promise<WorkflowWatcher | null> {
+  try {
+    await access(input.config.workflowPath);
+  } catch {
+    return null;
+  }
+
+  return await WorkflowWatcher.create({
+    workflowPath: input.config.workflowPath,
+    onReload: async ({ snapshot }) => {
+      if (!snapshot.dispatchValidation.ok) {
+        await input.logger.error(
+          "workflow_reload_rejected",
+          snapshot.dispatchValidation.error.message,
+          {
+            error_code: ERROR_CODES.workflowReloadRejected,
+            reason: snapshot.dispatchValidation.error.code,
+          },
+        );
+        return;
+      }
+
+      await input.onReload(snapshot.config);
+      await input.logger.info(
+        "workflow_reloaded",
+        "Applied updated workflow configuration.",
+        {
+          poll_interval_ms: snapshot.config.polling.intervalMs,
+          max_concurrent_agents: snapshot.config.agent.maxConcurrentAgents,
+        },
+      );
+    },
+    onError: async ({ error }) => {
+      await input.logger.error(
+        "workflow_reload_failed",
+        toErrorMessage(error),
+        {
+          error_code:
+            extractErrorCode(error) ?? ERROR_CODES.workflowReloadRejected,
+        },
+      );
+    },
+  });
 }
 
 async function cleanupTerminalIssueWorkspaces(input: {
@@ -501,6 +643,28 @@ async function cleanupTerminalIssueWorkspaces(input: {
       },
     );
   }
+}
+
+function createLinearTrackerFromConfig(
+  config: ResolvedWorkflowConfig,
+): LinearTrackerClient {
+  return new LinearTrackerClient({
+    endpoint: config.tracker.endpoint,
+    apiKey: config.tracker.apiKey,
+    projectSlug: config.tracker.projectSlug,
+    activeStates: config.tracker.activeStates,
+  });
+}
+
+function createWorkspaceManagerFromConfig(
+  config: ResolvedWorkflowConfig,
+): WorkspaceManager {
+  return new WorkspaceManager({
+    root: config.workspace.root,
+    hooks: new WorkspaceHookRunner({
+      config: config.hooks,
+    }),
+  });
 }
 
 async function createRuntimeLogger(input: {
@@ -668,4 +832,29 @@ function toErrorMessage(error: unknown): string {
   }
 
   return "worker failed";
+}
+
+function extractErrorCode(error: unknown): string | null {
+  if (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    typeof error.code === "string"
+  ) {
+    return error.code;
+  }
+
+  return null;
+}
+
+function supportsConfigUpdate(
+  value: AgentRunnerLike,
+): value is AgentRunnerLike & {
+  updateConfig(input: {
+    config: ResolvedWorkflowConfig;
+    tracker?: IssueTracker;
+    workspaceManager?: WorkspaceManager;
+  }): void;
+} {
+  return "updateConfig" in value && typeof value.updateConfig === "function";
 }

--- a/tests/cli/runtime-integration.test.ts
+++ b/tests/cli/runtime-integration.test.ts
@@ -8,13 +8,16 @@ import {
 } from "node:fs/promises";
 import { request as httpRequest } from "node:http";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { PassThrough } from "node:stream";
+import { fileURLToPath } from "node:url";
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { CLI_ACKNOWLEDGEMENT_FLAG, runCli } from "../../src/cli/main.js";
+import { resolveWorkflowConfig } from "../../src/config/config-resolver.js";
 import type { ResolvedWorkflowConfig } from "../../src/config/types.js";
+import { loadWorkflowDefinition } from "../../src/config/workflow-loader.js";
 import type { Issue } from "../../src/domain/model.js";
 import type { PollTickResult } from "../../src/orchestrator/core.js";
 import {
@@ -28,6 +31,10 @@ import type {
 } from "../../src/tracker/tracker.js";
 
 const tempDirs: string[] = [];
+const codexFixturePath = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "../fixtures/codex-fake-server.mjs",
+);
 
 afterEach(async () => {
   await Promise.allSettled(
@@ -243,6 +250,168 @@ Prompt body
       message: "tracker.api_key must be configured before dispatch.",
     } satisfies Partial<RuntimeHostStartupError>);
   });
+
+  it("reloads workflow changes into the running service and rejects invalid reloads", async () => {
+    const root = await createTempDir("symphony-task18-reload-");
+    const logsRoot = join(root, "logs");
+    const workflowPath = join(root, "WORKFLOW.md");
+    await writeFile(
+      workflowPath,
+      `---
+tracker:
+  kind: linear
+  api_key: token
+  project_slug: ENG
+polling:
+  interval_ms: 30000
+workspace:
+  root: ${join(root, "workspaces-a")}
+server:
+  port: 0
+---
+Prompt v1
+`,
+      "utf8",
+    );
+    const config = await resolveRuntimeConfig(workflowPath);
+    const service = await startRuntimeService({
+      config,
+      logsRoot,
+      tracker: createTracker({
+        candidates: [],
+      }),
+      stdout: new PassThrough(),
+    });
+
+    await writeFile(
+      workflowPath,
+      `---
+tracker:
+  kind: linear
+  api_key: token
+  project_slug: ENG
+polling:
+  interval_ms: 25
+workspace:
+  root: ${join(root, "workspaces-b")}
+server:
+  port: 0
+---
+Prompt v2
+`,
+      "utf8",
+    );
+
+    await vi.waitFor(() => {
+      expect(service.runtimeHost.getState().pollIntervalMs).toBe(25);
+    });
+
+    await writeFile(
+      workflowPath,
+      `---
+tracker:
+  kind: linear
+---
+Prompt invalid
+`,
+      "utf8",
+    );
+
+    await vi.waitFor(async () => {
+      const logFile = await readFile(join(logsRoot, "symphony.jsonl"), "utf8");
+      expect(logFile).toContain('"event":"workflow_reloaded"');
+      expect(logFile).toContain('"event":"workflow_reload_rejected"');
+    });
+
+    expect(service.runtimeHost.getState().pollIntervalMs).toBe(25);
+
+    await service.shutdown();
+  });
+
+  it("runs a real end-to-end issue cycle with workflow hooks and the fake codex app-server", async () => {
+    const root = await createTempDir("symphony-task18-e2e-");
+    const logsRoot = join(root, "logs");
+    const workspaceRoot = join(root, "workspaces");
+    const workflowPath = join(root, "WORKFLOW.md");
+    await writeFile(
+      workflowPath,
+      `---
+tracker:
+  kind: linear
+  api_key: token
+  project_slug: ENG
+polling:
+  interval_ms: 25
+workspace:
+  root: ${workspaceRoot}
+hooks:
+  after_create: printf created > created.txt
+  before_run: printf before > before-run.txt
+  after_run: printf after > after-run.txt
+codex:
+  command: node "${codexFixturePath}" linear-tool
+  approval_policy: full-auto
+  thread_sandbox: workspace-write
+  turn_sandbox_policy:
+    type: workspace-write
+  turn_timeout_ms: 2000
+  read_timeout_ms: 500
+  stall_timeout_ms: 2000
+agent:
+  max_turns: 3
+server:
+  port: 0
+---
+Implement {{ issue.identifier }} attempt={{ attempt }}
+`,
+      "utf8",
+    );
+    const tracker = new EndToEndTracker();
+    const config = await resolveRuntimeConfig(workflowPath);
+    const service = await startRuntimeService({
+      config,
+      logsRoot,
+      tracker,
+      stdout: new PassThrough(),
+    });
+
+    const workspacePath = join(workspaceRoot, "ISSUE-1");
+    await vi.waitFor(async () => {
+      const state = await service.runtimeHost.getRuntimeSnapshot();
+      expect(state.counts.running + state.counts.retrying).toBeGreaterThan(0);
+      await expect(
+        readFile(join(workspacePath, "created.txt"), "utf8"),
+      ).resolves.toBe("created");
+      await expect(
+        readFile(join(workspacePath, "before-run.txt"), "utf8"),
+      ).resolves.toBe("before");
+    });
+
+    await vi.waitFor(async () => {
+      const state = await service.runtimeHost.getRuntimeSnapshot();
+      expect(state.counts.retrying).toBe(1);
+    });
+    await service.runtimeHost.runRetryTimer("issue-1");
+    await vi.waitFor(async () => {
+      const state = await service.runtimeHost.getRuntimeSnapshot();
+      expect(state.counts.running).toBe(0);
+      expect(state.counts.retrying).toBe(0);
+      expect([...service.runtimeHost.getState().claimed]).toEqual([]);
+    });
+
+    const issueDetail = await sendRequest(service.dashboard?.port ?? 0, {
+      method: "GET",
+      path: "/api/v1/ISSUE-1",
+    });
+    expect(issueDetail.statusCode).toBe(404);
+
+    await service.shutdown();
+
+    const logFile = await readFile(join(logsRoot, "symphony.jsonl"), "utf8");
+    expect(logFile).toContain('"event":"runtime_starting"');
+    expect(tracker.fetchCandidateIssues).toHaveBeenCalled();
+    expect(tracker.fetchIssueStatesByIds).toHaveBeenCalled();
+  });
 });
 
 function createTracker(input?: {
@@ -269,6 +438,54 @@ function createTracker(input?: {
     fetchIssuesByStates: vi.fn(async () => terminalIssues),
     fetchIssueStatesByIds: vi.fn(async () => stateSnapshots),
   };
+}
+
+class EndToEndTracker implements IssueTracker {
+  readonly fetchCandidateIssues = vi.fn(async () => {
+    if (this.completed) {
+      return [];
+    }
+
+    return [
+      createIssue({
+        id: "issue-1",
+        identifier: "ISSUE-1",
+        state: "Todo",
+      }),
+    ];
+  });
+
+  readonly fetchIssuesByStates = vi.fn(async () => []);
+
+  readonly fetchIssueStatesByIds = vi.fn(async (issueIds: string[]) => {
+    if (!issueIds.includes("issue-1")) {
+      return [];
+    }
+
+    this.refreshFetches += 1;
+    if (this.refreshFetches === 1) {
+      return [
+        {
+          id: "issue-1",
+          identifier: "ISSUE-1",
+          state: "In Progress",
+        },
+      ];
+    }
+
+    this.completed = true;
+    return [
+      {
+        id: "issue-1",
+        identifier: "ISSUE-1",
+        state: "Done",
+      },
+    ];
+  });
+
+  private refreshFetches = 0;
+
+  private completed = false;
 }
 
 class ThrowingRuntimeHost extends OrchestratorRuntimeHost {
@@ -348,6 +565,12 @@ async function createTempDir(prefix: string): Promise<string> {
   const directory = await mkdtemp(join(tmpdir(), prefix));
   tempDirs.push(directory);
   return directory;
+}
+
+async function resolveRuntimeConfig(
+  workflowPath: string,
+): Promise<ResolvedWorkflowConfig> {
+  return resolveWorkflowConfig(await loadWorkflowDefinition(workflowPath), {});
 }
 
 async function sendRequest(


### PR DESCRIPTION
## Summary
- wire runtime workflow watching into the real service so `WORKFLOW.md` changes are re-applied without restart
- rebuild managed tracker/workspace dependencies on valid reload and keep the last known good config on invalid reloads
- add task 18 runtime integration coverage for workflow reloads and a fake-tracker + fake-codex end-to-end issue cycle

## Scope
This PR completes the task 18 end-to-end integration and hardening pass from `IMPLEMENTATION_PLAN.md`.

It focuses on runtime integration gaps rather than adding out-of-spec features:
- runtime-level workflow watch/reload/re-apply
- real workspace hook wiring in the managed runtime path
- deterministic end-to-end verification of one full orchestration cycle

## Spec alignment
- `SPEC.upstream.md` 17.1: workflow file changes now trigger re-read/re-apply without restart, while invalid reloads preserve the last known good effective config and emit operator-visible errors
- `SPEC.upstream.md` 18.1: hardens dynamic `WORKFLOW.md` reload/re-apply in the real service path and validates real orchestration flow coverage locally

## Test evidence
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`