### PR TITLE
Add release automation and package metadata

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,44 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.30.2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint
+        run: pnpm lint
+
+      - name: Typecheck
+        run: pnpm typecheck
+
+      - name: Test
+        run: pnpm test
+
+      - name: Build
+        run: pnpm build
+
+      - name: Verify npm package contents
+        run: npm pack --dry-run

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,71 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.30.2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+          registry-url: https://registry.npmjs.org
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint
+        run: pnpm lint
+
+      - name: Typecheck
+        run: pnpm typecheck
+
+      - name: Test
+        run: pnpm test
+
+      - name: Build
+        run: pnpm build
+
+      - name: Verify tag matches package version
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          PACKAGE_VERSION="$(node -p "require('./package.json').version")"
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          if [ "$PACKAGE_VERSION" != "$TAG_VERSION" ]; then
+            echo "package.json version ($PACKAGE_VERSION) does not match tag ($TAG_VERSION)"
+            exit 1
+          fi
+
+      - name: Pack
+        run: npm pack
+
+      - name: Publish to npm
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Create GitHub Release
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          files: symphony-ts-*.tgz

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 dist/
 node_modules/
 coverage/
+.DS_Store
+*.tgz
 
 .worktrees/

--- a/README.md
+++ b/README.md
@@ -37,6 +37,12 @@ moving from managing coding agents to managing work that needs to get done.
 pnpm install
 ```
 
+If you want the packaged CLI after publishing:
+
+```bash
+npm install -g symphony-ts
+```
+
 ### Develop
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -1,11 +1,32 @@
 {
   "name": "symphony-ts",
   "version": "0.1.0",
-  "private": true,
   "type": "module",
-  "bin": {
-    "symphony": "./dist/cli/main.js"
+  "description": "TypeScript implementation of Symphony",
+  "main": "./dist/src/index.js",
+  "types": "./dist/src/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/src/index.d.ts",
+      "import": "./dist/src/index.js"
+    },
+    "./package.json": "./package.json"
   },
+  "bin": {
+    "symphony": "./dist/src/cli/main.js"
+  },
+  "files": ["dist/src", "README.md"],
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/OasAIStudio/symphony-ts.git"
+  },
+  "bugs": {
+    "url": "https://github.com/OasAIStudio/symphony-ts/issues"
+  },
+  "homepage": "https://github.com/OasAIStudio/symphony-ts#readme",
   "engines": {
     "node": ">=22.0.0",
     "pnpm": ">=10.0.0"
@@ -13,6 +34,7 @@
   "packageManager": "pnpm@10.30.2",
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
+    "prepack": "pnpm build",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",


### PR DESCRIPTION
## Scope
- add CI workflow for lint, typecheck, test, build, and npm pack verification
- add tag-driven release workflow for GitHub Release and npm publish
- update package metadata for distributable npm packaging
- add npm global install line to README install section

## Verification
- pnpm lint
- pnpm build
- pnpm test
- npm pack --dry-run

## Notes
- release workflow expects the repository secret NPM_TOKEN
- package publish is triggered by pushing a tag like v0.1.0
- if the npm package name is unavailable, update the package name before the first publish