### PR TITLE
Align acceptance fixes with spec

### DIFF
--- a/src/agent/prompt-builder.ts
+++ b/src/agent/prompt-builder.ts
@@ -13,7 +13,7 @@ const liquidEngine = new Liquid({
 });
 
 export class PromptTemplateError extends Error {
-  readonly code = ERROR_CODES.promptRenderFailed;
+  readonly code: string;
   readonly kind: "template_parse_error" | "template_render_error";
 
   constructor(
@@ -23,6 +23,10 @@ export class PromptTemplateError extends Error {
   ) {
     super(message, options);
     this.name = "PromptTemplateError";
+    this.code =
+      kind === "template_parse_error"
+        ? ERROR_CODES.templateParseError
+        : ERROR_CODES.templateRenderError;
     this.kind = kind;
   }
 }
@@ -104,16 +108,16 @@ function toTemplateIssue(issue: Issue): Record<string, unknown> {
     description: issue.description,
     priority: issue.priority,
     state: issue.state,
-    branchName: issue.branchName,
+    branch_name: issue.branchName,
     url: issue.url,
     labels: [...issue.labels],
-    blockedBy: issue.blockedBy.map((blocker) => ({
+    blocked_by: issue.blockedBy.map((blocker) => ({
       id: blocker.id,
       identifier: blocker.identifier,
       state: blocker.state,
     })),
-    createdAt: issue.createdAt,
-    updatedAt: issue.updatedAt,
+    created_at: issue.createdAt,
+    updated_at: issue.updatedAt,
   };
 }
 

--- a/src/codex/app-server-client.ts
+++ b/src/codex/app-server-client.ts
@@ -713,7 +713,7 @@ export class CodexAppServerClient {
   private bumpStallTimer(activeTurn: ActiveTurn): void {
     clearTimeoutIfPresent(activeTurn.stallTimer);
 
-    if (this.options.stallTimeoutMs < 0) {
+    if (this.options.stallTimeoutMs <= 0) {
       activeTurn.stallTimer = null;
       return;
     }

--- a/src/orchestrator/runtime-host.ts
+++ b/src/orchestrator/runtime-host.ts
@@ -457,7 +457,8 @@ export async function startRuntimeService(
 
   const runPollCycle = async () => {
     try {
-      await runtimeHost.pollOnce();
+      const result = await runtimeHost.pollOnce();
+      await logPollCycleResult(logger, result);
       scheduleNextPoll();
     } catch (error) {
       await logger.error("runtime_poll_failed", toErrorMessage(error), {
@@ -567,6 +568,43 @@ export async function startRuntimeService(
     },
     shutdown,
   };
+}
+
+async function logPollCycleResult(
+  logger: StructuredLogger,
+  result: Awaited<ReturnType<OrchestratorRuntimeHost["pollOnce"]>>,
+): Promise<void> {
+  if (!result.validation.ok) {
+    await logger.error(
+      "dispatch_validation_failed",
+      result.validation.error.message,
+      {
+        error_code: result.validation.error.code,
+      },
+    );
+  }
+
+  if (result.reconciliationFetchFailed) {
+    await logger.warn(
+      "reconciliation_state_refresh_failed",
+      "Issue state reconciliation failed; keeping current workers running.",
+      {
+        outcome: "degraded",
+        reason: "tracker_state_refresh_failed",
+      },
+    );
+  }
+
+  if (result.trackerFetchFailed) {
+    await logger.warn(
+      "candidate_issue_fetch_failed",
+      "Tracker candidate fetch failed; dispatch skipped for this tick.",
+      {
+        outcome: "degraded",
+        reason: "tracker_candidate_fetch_failed",
+      },
+    );
+  }
 }
 
 async function createRuntimeWorkflowWatcher(input: {

--- a/tests/agent/prompt-builder.test.ts
+++ b/tests/agent/prompt-builder.test.ts
@@ -44,7 +44,10 @@ describe("prompt builder", () => {
           "# {{ issue.identifier }}",
           "{{ issue.title }}",
           "{% for label in issue.labels %}[{{ label }}]{% endfor %}",
-          "{% for blocker in issue.blockedBy %}{{ blocker.identifier }}:{{ blocker.state }}{% endfor %}",
+          "{% for blocker in issue.blocked_by %}{{ blocker.identifier }}:{{ blocker.state }}{% endfor %}",
+          "{{ issue.branch_name }}",
+          "{{ issue.created_at }}",
+          "{{ issue.updated_at }}",
           "attempt={{ attempt }}",
         ].join("\n"),
       },
@@ -56,6 +59,9 @@ describe("prompt builder", () => {
     expect(prompt).toContain("Ship prompt rendering");
     expect(prompt).toContain("[backend][automation]");
     expect(prompt).toContain("ABC-122:Todo");
+    expect(prompt).toContain("feature/abc-123");
+    expect(prompt).toContain("2026-03-06T00:00:00.000Z");
+    expect(prompt).toContain("2026-03-06T01:00:00.000Z");
     expect(prompt).toContain("attempt=2");
   });
 
@@ -123,7 +129,7 @@ describe("prompt builder", () => {
       }),
     ).rejects.toMatchObject({
       name: "PromptTemplateError",
-      code: ERROR_CODES.promptRenderFailed,
+      code: ERROR_CODES.templateRenderError,
       kind: "template_render_error",
     } satisfies Partial<PromptTemplateError>);
   });
@@ -139,7 +145,7 @@ describe("prompt builder", () => {
       }),
     ).rejects.toMatchObject({
       name: "PromptTemplateError",
-      code: ERROR_CODES.promptRenderFailed,
+      code: ERROR_CODES.templateRenderError,
       kind: "template_render_error",
     } satisfies Partial<PromptTemplateError>);
   });
@@ -155,7 +161,7 @@ describe("prompt builder", () => {
       }),
     ).rejects.toMatchObject({
       name: "PromptTemplateError",
-      code: ERROR_CODES.promptRenderFailed,
+      code: ERROR_CODES.templateParseError,
       kind: "template_parse_error",
     } satisfies Partial<PromptTemplateError>);
   });

--- a/tests/cli/runtime-integration.test.ts
+++ b/tests/cli/runtime-integration.test.ts
@@ -251,6 +251,34 @@ Prompt body
     } satisfies Partial<RuntimeHostStartupError>);
   });
 
+  it("logs operator-visible warnings when a poll tick cannot fetch candidate issues", async () => {
+    const stdout = new PassThrough();
+    let output = "";
+    stdout.setEncoding("utf8");
+    stdout.on("data", (chunk: string) => {
+      output += chunk;
+    });
+
+    const service = await startRuntimeService({
+      config: createConfig({
+        polling: {
+          intervalMs: 60_000,
+        },
+      }),
+      tracker: createTracker({
+        candidatesError: new Error("tracker unavailable"),
+      }),
+      stdout,
+    });
+
+    await vi.waitFor(() => {
+      expect(output).toContain('"event":"candidate_issue_fetch_failed"');
+    });
+
+    await service.shutdown();
+    expect(await service.waitForExit()).toBe(0);
+  });
+
   it("reloads workflow changes into the running service and rejects invalid reloads", async () => {
     const root = await createTempDir("symphony-task18-reload-");
     const logsRoot = join(root, "logs");

--- a/tests/codex/app-server-client.test.ts
+++ b/tests/codex/app-server-client.test.ts
@@ -297,6 +297,40 @@ describe("CodexAppServerClient", () => {
 
     await client.close();
   });
+
+  it("disables stall detection when stallTimeoutMs is zero", async () => {
+    const workspace = await createWorkspace();
+    const events: CodexClientEvent[] = [];
+    const client = createClient("turn-timeout", workspace, events, {
+      stallTimeoutMs: 0,
+      turnTimeoutMs: 50,
+    });
+
+    await expect(
+      client.startSession({
+        prompt: "Wait for turn timeout",
+        title: "ABC-123: Example",
+      }),
+    ).rejects.toMatchObject({
+      name: "CodexAppServerClientError",
+      code: ERROR_CODES.codexTurnTimeout,
+    } satisfies Partial<CodexAppServerClientError>);
+
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        event: "turn_ended_with_error",
+        errorCode: ERROR_CODES.codexTurnTimeout,
+      }),
+    );
+    expect(events).not.toContainEqual(
+      expect.objectContaining({
+        event: "turn_ended_with_error",
+        errorCode: ERROR_CODES.codexSessionStalled,
+      }),
+    );
+
+    await client.close();
+  });
 });
 
 function createClient(

--- a/tests/config/config-resolver.test.ts
+++ b/tests/config/config-resolver.test.ts
@@ -202,11 +202,14 @@ describe("config-resolver", () => {
   });
 
   it("blocks dispatch when required tracker settings are missing", () => {
-    const resolved = resolveWorkflowConfig({
-      workflowPath: "/repo/WORKFLOW.md",
-      promptTemplate: "Prompt",
-      config: {},
-    });
+    const resolved = resolveWorkflowConfig(
+      {
+        workflowPath: "/repo/WORKFLOW.md",
+        promptTemplate: "Prompt",
+        config: {},
+      },
+      {},
+    );
 
     const validation = validateDispatchConfig(resolved);
     expect(validation).toEqual({


### PR DESCRIPTION
## Summary
- align prompt template issue fields and template error codes with the spec
- disable codex stall detection when stall timeout is zero or below
- emit operator-visible poll tick warnings for dispatch and tracker failures
- add regression coverage for the acceptance fixes and stabilize config validation expectations

## Validation
- pnpm test
- pnpm typecheck
- pnpm lint