### PR TITLE
Fix remaining acceptance gaps

### DIFF
--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -158,7 +158,6 @@ export class AgentRunner {
     let issue = cloneIssue(input.issue);
     let workspace: Workspace | null = null;
     let client: AgentRunnerCodexClient | null = null;
-    let shouldRunAfterHook = false;
     let lastTurn: CodexTurnResult | null = null;
     let rateLimits: Record<string, unknown> | null = null;
     const liveSession = createEmptyLiveSession();
@@ -193,7 +192,6 @@ export class AgentRunner {
         name: "beforeRun",
         workspacePath: workspace.path,
       });
-      shouldRunAfterHook = true;
 
       runAttempt.status = "launching_agent_process";
       client = this.createCodexClient({
@@ -307,7 +305,7 @@ export class AgentRunner {
         await closeBestEffort(client);
       }
 
-      if (shouldRunAfterHook && workspace !== null) {
+      if (workspace !== null) {
         await this.hooks.runBestEffort({
           name: "afterRun",
           workspacePath: workspace.path,

--- a/src/orchestrator/runtime-host.ts
+++ b/src/orchestrator/runtime-host.ts
@@ -51,6 +51,7 @@ export interface RuntimeHostOptions {
   createAgentRunner?: (input: {
     onEvent: (event: AgentRunnerEvent) => void;
   }) => AgentRunnerLike;
+  logger?: StructuredLogger;
   workspaceManager?: WorkspaceManager;
   now?: () => Date;
 }
@@ -105,6 +106,8 @@ export class OrchestratorRuntimeHost implements DashboardServerHost {
 
   private readonly now: () => Date;
 
+  private readonly logger: StructuredLogger | null;
+
   private readonly workers = new Map<string, WorkerExecution>();
 
   private readonly orchestrator: OrchestratorCore;
@@ -121,15 +124,17 @@ export class OrchestratorRuntimeHost implements DashboardServerHost {
     this.config = options.config;
     this.tracker = options.tracker;
     this.now = options.now ?? (() => new Date());
+    this.logger = options.logger ?? null;
     this.workspaceManager =
       options.workspaceManager ??
-      createWorkspaceManagerFromConfig(options.config);
+      createWorkspaceManagerFromConfig(options.config, this.logger);
     this.agentEventSink = (event) => {
       void this.enqueue(async () => {
         this.orchestrator.onCodexEvent({
           issueId: event.issueId,
           event,
         });
+        await logAgentEvent(this.logger, event);
       });
     };
     this.managesAgentRunner =
@@ -289,6 +294,14 @@ export class OrchestratorRuntimeHost implements DashboardServerHost {
     workerHandle: WorkerExecution;
     monitorHandle: Promise<void>;
   }> {
+    await this.logger?.info("worker_spawned", "Worker spawned for issue.", {
+      outcome: "started",
+      issue_id: issue.id,
+      issue_identifier: issue.identifier,
+      attempt,
+      state: issue.state,
+    });
+
     const controller = new AbortController();
     const execution: WorkerExecution = {
       issueId: issue.id,
@@ -358,6 +371,23 @@ export class OrchestratorRuntimeHost implements DashboardServerHost {
   ): Promise<void> {
     this.workers.delete(execution.issueId);
 
+    await this.logger?.log(
+      input.outcome === "normal" ? "info" : "error",
+      input.outcome === "normal"
+        ? "worker_exit_normal"
+        : "worker_exit_abnormal",
+      input.outcome === "normal"
+        ? "Worker completed normally."
+        : "Worker completed abnormally.",
+      {
+        outcome: input.outcome === "normal" ? "completed" : "failed",
+        ...(input.reason === undefined ? {} : { reason: input.reason }),
+        issue_id: execution.issueId,
+        issue_identifier: execution.issueIdentifier,
+        session_id: execution.lastResult?.liveSession.sessionId ?? null,
+      },
+    );
+
     if (execution.stopRequest?.cleanupWorkspace === true) {
       await this.workspaceManager.removeForIssue(execution.issueIdentifier);
     }
@@ -404,21 +434,23 @@ export async function startRuntimeService(
     );
   }
 
-  let currentConfig = options.config;
-  let tracker = options.tracker ?? createLinearTrackerFromConfig(currentConfig);
-  let workspaceManager =
-    options.workspaceManager ?? createWorkspaceManagerFromConfig(currentConfig);
   const logger =
     options.logger ??
     (await createRuntimeLogger({
       logsRoot: options.logsRoot ?? null,
       ...(options.stdout === undefined ? {} : { stdout: options.stdout }),
     }));
+  let currentConfig = options.config;
+  let tracker = options.tracker ?? createLinearTrackerFromConfig(currentConfig);
+  let workspaceManager =
+    options.workspaceManager ??
+    createWorkspaceManagerFromConfig(currentConfig, logger);
   const runtimeHost =
     options.runtimeHost ??
     new OrchestratorRuntimeHost({
       config: currentConfig,
       tracker,
+      logger,
       workspaceManager,
       ...(options.now === undefined ? {} : { now: options.now }),
     });
@@ -492,7 +524,10 @@ export async function startRuntimeService(
             }
 
             if (usesManagedWorkspaceManager) {
-              workspaceManager = createWorkspaceManagerFromConfig(nextConfig);
+              workspaceManager = createWorkspaceManagerFromConfig(
+                nextConfig,
+                logger,
+              );
             }
 
             runtimeHost.updateConfig({
@@ -696,11 +731,17 @@ function createLinearTrackerFromConfig(
 
 function createWorkspaceManagerFromConfig(
   config: ResolvedWorkflowConfig,
+  logger?: StructuredLogger | null,
 ): WorkspaceManager {
   return new WorkspaceManager({
     root: config.workspace.root,
     hooks: new WorkspaceHookRunner({
       config: config.hooks,
+      ...(logger === undefined || logger === null
+        ? {}
+        : {
+            log: createWorkspaceHookLogger(logger),
+          }),
     }),
   });
 }
@@ -740,6 +781,120 @@ function createQueuedTimerScheduler(input: {
       }
     },
   };
+}
+
+function createWorkspaceHookLogger(logger: StructuredLogger): (entry: {
+  level: "info" | "warn" | "error";
+  event:
+    | "workspace_hook_started"
+    | "workspace_hook_completed"
+    | "workspace_hook_failed"
+    | "workspace_hook_timed_out";
+  hook: string;
+  workspacePath: string;
+  durationMs?: number;
+  exitCode?: number | null;
+  errorCode?: string;
+  stdout?: string;
+  stderr?: string;
+}) => void {
+  return (entry) => {
+    void logger.log(
+      entry.level,
+      entry.event,
+      `Workspace hook ${entry.hook} ${toHookMessageSuffix(entry.event)}.`,
+      {
+        ...(entry.event === "workspace_hook_completed"
+          ? { outcome: "completed" }
+          : entry.event === "workspace_hook_started"
+            ? { outcome: "started" }
+            : { outcome: "failed" }),
+        hook: entry.hook,
+        workspace_path: entry.workspacePath,
+        ...(entry.durationMs === undefined
+          ? {}
+          : { duration_ms: entry.durationMs }),
+        ...(entry.exitCode === undefined ? {} : { exit_code: entry.exitCode }),
+        ...(entry.errorCode === undefined
+          ? {}
+          : { error_code: entry.errorCode }),
+      },
+    );
+  };
+}
+
+async function logAgentEvent(
+  logger: StructuredLogger | null,
+  event: AgentRunnerEvent,
+): Promise<void> {
+  if (logger === null) {
+    return;
+  }
+
+  const level =
+    event.event === "turn_failed" ||
+    event.event === "turn_ended_with_error" ||
+    event.event === "startup_failed" ||
+    event.event === "turn_input_required" ||
+    event.event === "malformed"
+      ? "error"
+      : event.event === "unsupported_tool_call"
+        ? "warn"
+        : "info";
+
+  const outcome =
+    event.event === "session_started"
+      ? "started"
+      : event.event === "turn_completed"
+        ? "completed"
+        : event.event === "approval_auto_approved"
+          ? "approved"
+          : event.event === "turn_failed" ||
+              event.event === "turn_cancelled" ||
+              event.event === "turn_ended_with_error" ||
+              event.event === "startup_failed" ||
+              event.event === "turn_input_required" ||
+              event.event === "malformed"
+            ? "failed"
+            : undefined;
+
+  await logger.log(level, event.event, event.message ?? event.event, {
+    ...(outcome === undefined ? {} : { outcome }),
+    ...(event.errorCode === undefined ? {} : { error_code: event.errorCode }),
+    issue_id: event.issueId,
+    issue_identifier: event.issueIdentifier,
+    session_id: event.sessionId ?? null,
+    thread_id: event.threadId ?? null,
+    turn_id: event.turnId ?? null,
+    attempt: event.attempt,
+    workspace_path: event.workspacePath,
+    ...(event.usage === undefined
+      ? {}
+      : {
+          input_tokens: event.usage.inputTokens,
+          output_tokens: event.usage.outputTokens,
+          total_tokens: event.usage.totalTokens,
+        }),
+  });
+}
+
+function toHookMessageSuffix(
+  event:
+    | "workspace_hook_started"
+    | "workspace_hook_completed"
+    | "workspace_hook_failed"
+    | "workspace_hook_timed_out",
+): string {
+  switch (event) {
+    case "workspace_hook_started":
+      return "started";
+    case "workspace_hook_completed":
+      return "completed";
+    case "workspace_hook_failed":
+      return "failed";
+    case "workspace_hook_timed_out":
+      return "timed out";
+  }
 }
 
 function toRunningIssueDetail(

--- a/tests/agent/runner.test.ts
+++ b/tests/agent/runner.test.ts
@@ -128,7 +128,7 @@ describe("AgentRunner", () => {
     expect(prompts[1]).not.toContain("Initial prompt for ABC-123 attempt=2");
   });
 
-  it("fails immediately when before_run fails and does not invoke after_run", async () => {
+  it("fails immediately when before_run fails and still invokes after_run best-effort", async () => {
     const root = await createRoot();
     const hooks = {
       run: vi.fn(async ({ name }: { name: string }) => {
@@ -167,7 +167,10 @@ describe("AgentRunner", () => {
     } satisfies Partial<AgentRunnerError>);
 
     expect(createCodexClient).not.toHaveBeenCalled();
-    expect(hooks.runBestEffort).not.toHaveBeenCalled();
+    expect(hooks.runBestEffort).toHaveBeenCalledWith({
+      name: "afterRun",
+      workspacePath: join(root, "ABC-123"),
+    });
   });
 
   it("removes temporary workspace artifacts before each attempt starts", async () => {

--- a/tests/cli/runtime-integration.test.ts
+++ b/tests/cli/runtime-integration.test.ts
@@ -437,6 +437,11 @@ Implement {{ issue.identifier }} attempt={{ attempt }}
 
     const logFile = await readFile(join(logsRoot, "symphony.jsonl"), "utf8");
     expect(logFile).toContain('"event":"runtime_starting"');
+    expect(logFile).toContain('"event":"workspace_hook_started"');
+    expect(logFile).toContain('"event":"workspace_hook_completed"');
+    expect(logFile).toContain('"event":"worker_spawned"');
+    expect(logFile).toContain('"issue_id":"issue-1"');
+    expect(logFile).toContain('"issue_identifier":"ISSUE-1"');
     expect(tracker.fetchCandidateIssues).toHaveBeenCalled();
     expect(tracker.fetchIssueStatesByIds).toHaveBeenCalled();
   });

--- a/tests/orchestrator/runtime-host.test.ts
+++ b/tests/orchestrator/runtime-host.test.ts
@@ -6,6 +6,10 @@ import type {
 } from "../../src/agent/runner.js";
 import type { ResolvedWorkflowConfig } from "../../src/config/types.js";
 import type { Issue } from "../../src/domain/model.js";
+import {
+  type StructuredLogEntry,
+  StructuredLogger,
+} from "../../src/logging/structured-logger.js";
 import { OrchestratorRuntimeHost } from "../../src/orchestrator/runtime-host.js";
 import type {
   IssueStateSnapshot,
@@ -194,6 +198,56 @@ describe("OrchestratorRuntimeHost", () => {
       coalesced: true,
     });
     expect(tracker.fetchCandidateIssues).toHaveBeenCalledTimes(1);
+  });
+
+  it("emits issue and session context for agent lifecycle logs", async () => {
+    const tracker = createTracker();
+    const fakeRunner = new FakeAgentRunner();
+    const entries: StructuredLogEntry[] = [];
+    const logger = new StructuredLogger([
+      {
+        write(entry) {
+          entries.push(entry);
+        },
+      },
+    ]);
+    const host = new OrchestratorRuntimeHost({
+      config: createConfig(),
+      tracker,
+      logger,
+      createAgentRunner: ({ onEvent }) => {
+        fakeRunner.onEvent = onEvent;
+        return fakeRunner;
+      },
+      now: () => new Date("2026-03-06T00:00:05.000Z"),
+    });
+
+    await host.pollOnce();
+    fakeRunner.emit("1", {
+      event: "session_started",
+      timestamp: "2026-03-06T00:00:01.000Z",
+      codexAppServerPid: "1001",
+      sessionId: "thread-1-turn-1",
+      threadId: "thread-1",
+      turnId: "turn-1",
+    });
+    await host.flushEvents();
+
+    expect(entries).toContainEqual(
+      expect.objectContaining({
+        event: "worker_spawned",
+        issue_id: "1",
+        issue_identifier: "ISSUE-1",
+      }),
+    );
+    expect(entries).toContainEqual(
+      expect.objectContaining({
+        event: "session_started",
+        issue_id: "1",
+        issue_identifier: "ISSUE-1",
+        session_id: "thread-1-turn-1",
+      }),
+    );
   });
 });
 


### PR DESCRIPTION
## Summary
- run after_run best-effort whenever a workspace exists, including before_run failures
- wire structured logging into workspace hooks, worker lifecycle, and agent session events
- add regression coverage for hook cleanup semantics and issue/session log context

## Validation
- pnpm test
- pnpm typecheck
- pnpm lint