### PR TITLE
Fix Linear candidate query compatibility

### DIFF
--- a/src/tracker/linear-client.ts
+++ b/src/tracker/linear-client.ts
@@ -83,6 +83,7 @@ export class LinearTrackerClient implements IssueTracker {
       projectSlug: this.requireProjectSlug(),
       activeStates: this.activeStates,
       first: this.pageSize,
+      relationFirst: this.pageSize,
     });
   }
 
@@ -95,6 +96,7 @@ export class LinearTrackerClient implements IssueTracker {
       projectSlug: this.requireProjectSlug(),
       stateNames,
       first: this.pageSize,
+      relationFirst: this.pageSize,
     });
   }
 

--- a/src/tracker/linear-normalize.ts
+++ b/src/tracker/linear-normalize.ts
@@ -25,6 +25,13 @@ interface LinearIssueNode {
   }> | null;
   inverseRelations?: LinearConnection<{
     type?: unknown;
+    issue?: {
+      id?: unknown;
+      identifier?: unknown;
+      state?: {
+        name?: unknown;
+      } | null;
+    } | null;
     sourceIssue?: {
       id?: unknown;
       identifier?: unknown;
@@ -145,7 +152,7 @@ function normalizeBlockedBy(
       return [];
     }
 
-    return [normalizeBlocker(relation.sourceIssue)];
+    return [normalizeBlocker(relation.issue ?? relation.sourceIssue)];
   });
 }
 

--- a/src/tracker/linear-queries.ts
+++ b/src/tracker/linear-queries.ts
@@ -6,6 +6,9 @@ const ISSUE_FIELDS = `
   priority
   branchName
   url
+  assignee {
+    id
+  }
   createdAt
   updatedAt
   state {
@@ -16,10 +19,10 @@ const ISSUE_FIELDS = `
       name
     }
   }
-  inverseRelations {
+  inverseRelations(first: $relationFirst) {
     nodes {
       type
-      sourceIssue {
+      issue {
         id
         identifier
         state {
@@ -35,6 +38,7 @@ export const LINEAR_CANDIDATE_ISSUES_QUERY = `
     $projectSlug: String!
     $activeStates: [String!]!
     $first: Int!
+    $relationFirst: Int!
     $after: String
   ) {
     issues(
@@ -62,6 +66,7 @@ export const LINEAR_ISSUES_BY_STATES_QUERY = `
     $projectSlug: String!
     $stateNames: [String!]!
     $first: Int!
+    $relationFirst: Int!
     $after: String
   ) {
     issues(

--- a/tests/tracker/linear-client.test.ts
+++ b/tests/tracker/linear-client.test.ts
@@ -73,6 +73,7 @@ describe("LinearTrackerClient", () => {
       projectSlug: "ENG",
       activeStates: ["Todo", "In Progress"],
       first: 50,
+      relationFirst: 50,
       after: null,
     });
 
@@ -81,6 +82,7 @@ describe("LinearTrackerClient", () => {
       projectSlug: "ENG",
       activeStates: ["Todo", "In Progress"],
       first: 50,
+      relationFirst: 50,
       after: "cursor-1",
     });
   });
@@ -288,6 +290,7 @@ function issueNode(input: {
     priority: 2,
     branchName: null,
     url: null,
+    assignee: null,
     createdAt: input.createdAt,
     updatedAt: input.createdAt,
     state: {

--- a/tests/tracker/linear-normalize.test.ts
+++ b/tests/tracker/linear-normalize.test.ts
@@ -29,7 +29,7 @@ describe("linear-normalize", () => {
         nodes: [
           {
             type: "blocks",
-            sourceIssue: {
+            issue: {
               id: "issue-0",
               identifier: "ENG-100",
               state: {
@@ -39,7 +39,7 @@ describe("linear-normalize", () => {
           },
           {
             type: "relatesTo",
-            sourceIssue: {
+            issue: {
               id: "issue-x",
               identifier: "ENG-X",
               state: {
@@ -71,6 +71,39 @@ describe("linear-normalize", () => {
       createdAt: "2026-03-01T00:00:00.000Z",
       updatedAt: "2026-03-02T12:34:56.789Z",
     });
+  });
+
+  it("accepts legacy blocker payloads that still use sourceIssue", () => {
+    const issue = normalizeLinearIssue({
+      id: "issue-1",
+      identifier: "ENG-123",
+      title: "Implement adapter",
+      state: {
+        name: "Todo",
+      },
+      inverseRelations: {
+        nodes: [
+          {
+            type: "blocks",
+            sourceIssue: {
+              id: "issue-0",
+              identifier: "ENG-100",
+              state: {
+                name: "In Progress",
+              },
+            },
+          },
+        ],
+      },
+    });
+
+    expect(issue.blockedBy).toEqual([
+      {
+        id: "issue-0",
+        identifier: "ENG-100",
+        state: "In Progress",
+      },
+    ]);
   });
 
   it("returns null for non-integer priority and invalid timestamps", () => {


### PR DESCRIPTION
## Summary
- align the TypeScript Linear candidate queries with the upstream GraphQL shape
- include relation pagination and assignee fields needed by the real Linear workflow
- keep blocker normalization compatible with both `issue` and legacy `sourceIssue` payloads

## Validation
- pnpm test tests/tracker/linear-client.test.ts tests/tracker/linear-normalize.test.ts
- pnpm build
- real workflow smoke test against /Users/wangruobing/Personal/symphony/elixir/WORKFLOW.linear-demo-oas-demo.md and a temporary variant including `In Review` in `active_states`
  - before fix: TypeScript runtime failed with Linear HTTP 400 while upstream dispatched successfully
  - after fix: TypeScript runtime dispatched the same issues as upstream in the temporary workflow smoke test