### PR TITLE
Improve README quickstart flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ moving from managing coding agents to managing work that needs to get done.
 ### Requirements
 
 - Node.js `>= 22`
-- pnpm `>= 10`
 - a repository with a valid `WORKFLOW.md`
 - tracker credentials such as `LINEAR_API_KEY`
 - a coding agent runtime that supports app-server mode, such as `codex app-server`
@@ -124,6 +123,8 @@ Once Symphony is running, it will:
 - keep retry, reconciliation, and cleanup state visible to operators
 
 ### Develop
+
+If you are developing Symphony itself rather than using the published CLI, you will also need `pnpm >= 10`.
 
 ```bash
 pnpm install


### PR DESCRIPTION
## Problem
The repository README explained the TypeScript implementation in detail, but it did not give either humans or coding agents a short, reliable startup path. The action path was interrupted by roadmap content, and the documented examples omitted required runtime details such as the build step, required CLI acknowledgement flag, and Linear workflow fields.

## Scope
- add a human-focused quickstart with the real startup commands
- add a collapsible agent prompt for setup and startup
- add a minimal WORKFLOW.md example with the required Linear fields
- move roadmap content below the usage and product explanation sections

## Testing
- No runnable tests required; documentation-only change.