### PR TITLE
Fix global CLI entrypoint

### DIFF
--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 
+import { realpathSync } from "node:fs";
 import { resolve } from "node:path";
-import { pathToFileURL } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 import { resolveWorkflowConfig } from "../config/config-resolver.js";
 import { WORKFLOW_FILENAME } from "../config/defaults.js";
@@ -220,6 +221,23 @@ export async function main(): Promise<void> {
   process.exitCode = exitCode;
 }
 
+export function shouldRunAsCli(
+  importMetaUrl: string,
+  entryPath: string | undefined,
+): boolean {
+  if (!entryPath) {
+    return false;
+  }
+
+  try {
+    return (
+      realpathSync(fileURLToPath(importMetaUrl)) === realpathSync(entryPath)
+    );
+  } catch {
+    return importMetaUrl === pathToFileURL(entryPath).href;
+  }
+}
+
 function readValueFlag(
   argv: readonly string[],
   index: number,
@@ -268,9 +286,6 @@ function renderUsage(): string {
   ].join("\n");
 }
 
-if (
-  process.argv[1] &&
-  import.meta.url === pathToFileURL(process.argv[1]).href
-) {
+if (shouldRunAsCli(import.meta.url, process.argv[1])) {
   void main();
 }

--- a/tests/cli/main.test.ts
+++ b/tests/cli/main.test.ts
@@ -1,6 +1,7 @@
-import { mkdtemp, writeFile } from "node:fs/promises";
+import { mkdtemp, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { pathToFileURL } from "node:url";
 
 import { describe, expect, it, vi } from "vitest";
 
@@ -9,6 +10,7 @@ import {
   applyCliOverrides,
   parseCliArgs,
   runCli,
+  shouldRunAsCli,
 } from "../../src/cli/main.js";
 import type { ResolvedWorkflowConfig } from "../../src/config/types.js";
 
@@ -59,6 +61,30 @@ describe("cli", () => {
 
     expect(runtime.config.server.port).toBe(8080);
     expect(runtime.logsRoot).toBe("/repo/runtime-logs");
+  });
+
+  it("treats symlinked executables as the CLI entrypoint", async () => {
+    const workspace = await mkdtemp(join(tmpdir(), "symphony-task-cli-link-"));
+    const cliPath = join(workspace, "main.js");
+    const symlinkPath = join(workspace, "symphony");
+
+    await writeFile(cliPath, "#!/usr/bin/env node\n", "utf8");
+    await symlink(cliPath, symlinkPath);
+
+    expect(shouldRunAsCli(pathToFileURL(cliPath).href, symlinkPath)).toBe(true);
+  });
+
+  it("returns false when the resolved entrypoint differs from the module path", async () => {
+    const workspace = await mkdtemp(
+      join(tmpdir(), "symphony-task-cli-mismatch-"),
+    );
+    const cliPath = join(workspace, "main.js");
+    const otherPath = join(workspace, "other.js");
+
+    await writeFile(cliPath, "#!/usr/bin/env node\n", "utf8");
+    await writeFile(otherPath, "#!/usr/bin/env node\n", "utf8");
+
+    expect(shouldRunAsCli(pathToFileURL(cliPath).href, otherPath)).toBe(false);
   });
 
   it("defaults to loading ./WORKFLOW.md from cwd when no workflow path is given", async () => {


### PR DESCRIPTION
## Problem
Global installs created a `symphony` executable, but running `symphony --help` exited silently instead of invoking the CLI. The ESM entrypoint only called `main()` when `process.argv[1]` matched `import.meta.url` exactly, which breaks when the executable is launched through the symlinked global bin path created by npm.

## Scope
- resolve the CLI entrypoint through real paths before comparing it to the module file
- keep a URL comparison fallback for paths that cannot be resolved
- add tests covering symlinked entrypoints and mismatched entrypoints

## Verification
- `pnpm build`
- `pnpm exec vitest run tests/cli/main.test.ts`
- packed the branch locally, installed the tarball globally, and verified `symphony --help` prints usage

## Testing Notes
- `pnpm test -- --run tests/cli/main.test.ts` also surfaced one existing unrelated failure in `tests/cli/runtime-integration.test.ts`.