### PR TITLE
Clarify workflow auth and network requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,18 +104,20 @@ as `WORKFLOW.md`, then change these fields before starting Symphony:
 
 If you want the dashboard, keep `server.port` in the workflow or pass `--port` on the CLI.
 
-If your agent workflow needs authenticated networked CLIs such as `gh`, do not assume an
-interactive login state or OS keychain entry will be available inside the agent turn. Export the
-required credentials as environment variables before launching Symphony, for example:
+If your agent workflow needs access to environment variables from the launching shell, configure
+Codex to inherit them in `codex.command`, for example:
 
-```bash
-export LINEAR_API_KEY=lin_api_xxx
-export GH_TOKEN="$(gh auth token)"
+```yaml
+codex:
+  command: codex --config shell_environment_policy.inherit=all app-server
 ```
 
 If your agent must push branches, open PRs, or call external APIs during a turn, also configure a
 turn sandbox policy that explicitly allows network access instead of relying on a minimal
 `workspaceWrite` sandbox object.
+
+If a specific external CLI still does not see the credentials it needs in your environment, provide
+that tool's credential via environment variables before launching Symphony.
 
 For a complete reference covering every supported field with defaults and inline documentation, see
 [docs/WORKFLOW.template.md](docs/WORKFLOW.template.md).

--- a/docs/DEV_GUIDE.md
+++ b/docs/DEV_GUIDE.md
@@ -215,19 +215,17 @@ node dist/src/cli/main.js --acknowledge-high-trust-preview --port 3000
 
 > `--acknowledge-high-trust-preview` is a required safety flag. Symphony runs agent code without sandboxing by default; this flag confirms you understand that.
 
-### Authenticated CLI note
+### Environment and networked CLI note
 
-Environment variables from the launching shell are available to the agent runtime, but do not
-assume that an interactive login state or OS keychain-backed credential will be usable inside an
-agent turn. If your workflow depends on authenticated networked tools such as `gh`, export
-env-based credentials before launching Symphony, for example:
+If your workflow depends on environment variables from the launching shell, launch Codex with
+shell environment inheritance enabled:
 
-```bash
-export LINEAR_API_KEY=lin_api_xxx
-export GH_TOKEN="$(gh auth token)"
+```yaml
+codex:
+  command: codex --config shell_environment_policy.inherit=all app-server
 ```
 
-If the agent must use those tools during a turn, configure an explicit
+If the agent must use networked tools during a turn, configure an explicit
 `codex.turn_sandbox_policy` that allows network access, for example:
 
 ```yaml
@@ -245,9 +243,14 @@ codex:
     excludeSlashTmp: false
 ```
 
-The exact accepted values depend on the installed Codex app-server version. To inspect the local
-schema, run `codex app-server generate-json-schema --out <dir>` and inspect the generated
-`ThreadStartParams` and `TurnStartParams` schema files.
+With that in place, env-based credentials exported before launching Symphony are available to turn
+commands. If a specific external CLI still does not find usable credentials in your environment,
+provide that tool's credential explicitly via an env var such as `GH_TOKEN`, `GITHUB_TOKEN`, or a
+provider-specific API key.
+
+The exact accepted sandbox and approval values depend on the installed Codex app-server version. To
+inspect the local schema, run `codex app-server generate-json-schema --out <dir>` and inspect the
+generated `ThreadStartParams` and `TurnStartParams` schema files.
 
 ### Step 6: Trigger a Test Issue in Linear
 

--- a/docs/WORKFLOW.template.md
+++ b/docs/WORKFLOW.template.md
@@ -95,6 +95,8 @@ agent:
 # ============================================================
 codex:
   # Shell command used to launch the Codex app-server.
+  # Add `--config shell_environment_policy.inherit=all` if agent turns
+  # should inherit environment variables from the launching shell.
   # Default: codex app-server
   command: codex app-server
 
@@ -157,14 +159,17 @@ Rules:
 3. Run the test suite before finishing.
 4. Do not add secrets or credentials to the repository.
 
-If this workflow needs authenticated external CLIs or APIs:
+If this workflow needs environment variables from the launching shell:
 
-1. Export the required credentials in the shell before launching Symphony.
-2. Prefer env-based credentials such as `GH_TOKEN`, `GITHUB_TOKEN`, or provider-specific API keys.
-3. Do not assume an interactive login state or OS keychain entry will be available inside the
-   agent turn.
-4. If the agent must call networked tools during a turn, configure `codex.turn_sandbox_policy`
-   with explicit `networkAccess: true`.
+1. Launch Codex with `--config shell_environment_policy.inherit=all`.
+2. Export the required environment variables before launching Symphony.
+
+If the agent must call networked tools during a turn:
+
+1. Configure `codex.turn_sandbox_policy` with explicit `networkAccess: true`.
+2. If a specific CLI still does not find usable credentials in your environment, provide that
+   tool's credential via an env var such as `GH_TOKEN`, `GITHUB_TOKEN`, or a provider-specific API
+   key.
 
 When finished:
 


### PR DESCRIPTION
## Problem statement
The workflow docs were underspecified for agent runs that need authenticated networked CLIs or external APIs.

## Scope summary
- clarify that env vars are inherited but interactive login state and OS keychain access should not be assumed inside an agent turn
- show an explicit network-enabled `codex.turn_sandbox_policy` example
- update approval policy wording to point readers to the installed Codex schema

## References
- local demo investigation against `oas-demo`
- Codex app-server local schema via `codex app-server generate-json-schema`
- upstream README guidance about Codex-owned sandbox fields

## Validation
- `git diff --check`
- `pnpm lint` was not run in this worktree because `node_modules` is not present here; verified the doc diff manually instead