### PR TITLE
fix: stop workers missing from reconciliation

### DIFF
--- a/src/orchestrator/core.ts
+++ b/src/orchestrator/core.ts
@@ -462,6 +462,7 @@ export class OrchestratorCore {
     const terminalStates = toNormalizedStateSet(
       this.config.tracker.terminalStates,
     );
+    const refreshedIds = new Set(refreshed.map((snapshot) => snapshot.id));
 
     for (const snapshot of refreshed) {
       const runningEntry = this.state.running[snapshot.id];
@@ -484,6 +485,21 @@ export class OrchestratorCore {
           state: snapshot.state,
         };
         runningEntry.identifier = snapshot.identifier;
+        continue;
+      }
+
+      stopRequests.push(
+        await this.requestStop(runningEntry, false, "inactive_state"),
+      );
+    }
+
+    for (const runningId of runningIds) {
+      if (refreshedIds.has(runningId)) {
+        continue;
+      }
+
+      const runningEntry = this.state.running[runningId];
+      if (runningEntry === undefined) {
         continue;
       }
 

--- a/tests/orchestrator/core.test.ts
+++ b/tests/orchestrator/core.test.ts
@@ -141,6 +141,25 @@ describe("orchestrator core", () => {
     ]);
   });
 
+  it("requests stop when reconciliation no longer returns a running issue", async () => {
+    const tracker = createTracker({
+      statesById: [],
+    });
+    const orchestrator = createOrchestrator({ tracker });
+
+    await orchestrator.pollTick();
+    const result = await orchestrator.pollTick();
+
+    expect(result.stopRequests).toEqual([
+      {
+        issueId: "1",
+        issueIdentifier: "ISSUE-1",
+        cleanupWorkspace: false,
+        reason: "inactive_state",
+      },
+    ]);
+  });
+
   it("treats reconciliation with no running issues as a no-op", async () => {
     const tracker = createTracker({
       candidates: [],


### PR DESCRIPTION
## Summary
- stop running workers when reconciliation no longer returns their issue id
- treat missing reconciliation snapshots as inactive issues to avoid zombie workers
- add a regression test for the missing-issue reconciliation case

## Testing
- pnpm test tests/orchestrator/core.test.ts
- pnpm typecheck

Closes #45